### PR TITLE
Allow configuring M3U download timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Sistema profissional para importação de listas **M3U** diretamente no **XUI.ON
 
 ## 📝 Requisitos
 
-- Servidor com **PHP 7.4+**  
-- Banco de dados **MySQL/MariaDB**  
+- Servidor com **PHP 7.4+**
+- Banco de dados **MySQL/MariaDB**
 - Acesso ao **XUI.ONE**
+
+### ⏱️ Ajustando o tempo limite de download da M3U
+
+Algumas listas M3U podem demorar vários minutos para serem transferidas. O backend respeita a variável de ambiente `IMPORTADOR_M3U_TIMEOUT` (em segundos) para definir o tempo limite utilizado ao baixar a lista e para o `default_socket_timeout` do PHP. Caso não seja definido, o sistema utiliza 600 segundos (10 minutos). Ajuste esse valor conforme a velocidade do servidor de origem e o tamanho da lista.
 
 ---
 

--- a/server/process_canais.php
+++ b/server/process_canais.php
@@ -1,7 +1,15 @@
 <?php
 
 set_time_limit(0);
-ini_set('default_socket_timeout', '300');
+
+$timeoutEnv = getenv('IMPORTADOR_M3U_TIMEOUT');
+if ($timeoutEnv !== false && is_numeric($timeoutEnv) && (int)$timeoutEnv > 0) {
+    $streamTimeout = (int)$timeoutEnv;
+} else {
+    $streamTimeout = 600; // 10 minutes default to support slower transfers
+}
+
+ini_set('default_socket_timeout', (string) $streamTimeout);
 
 // import.php - Recebe dados do cliente, salva M3U, insere no banco XUI e registra caminho na tabela clientes_import
 // CONFIGURAÇÃO: conexão com banco de administração (onde a tabela clientes_import está)
@@ -47,8 +55,8 @@ $fullPath = $uploadDir . $filename;
 
 // ---------- BAIXAR M3U ----------
 $opts = stream_context_create([
-    'http' => ['timeout'=>300,'follow_location'=>1,'user_agent'=>'Importador-XUI/1.0'],
-    'https'=> ['timeout'=>300,'follow_location'=>1,'user_agent'=>'Importador-XUI/1.0']
+    'http' => ['timeout' => $streamTimeout, 'follow_location' => 1, 'user_agent' => 'Importador-XUI/1.0'],
+    'https'=> ['timeout' => $streamTimeout, 'follow_location' => 1, 'user_agent' => 'Importador-XUI/1.0']
 ]);
 
 $contents = @file_get_contents($m3uUrl, false, $opts);


### PR DESCRIPTION
## Summary
- allow configuring the M3U download timeout through the IMPORTADOR_M3U_TIMEOUT environment variable with a higher default
- reuse the configured timeout for HTTP/HTTPS stream contexts used by file_get_contents
- document the timeout knob so operators can adjust it for slow sources

## Testing
- php -l server/process_canais.php

------
https://chatgpt.com/codex/tasks/task_e_68df1df95eb0832bb46fa189236865ad