### PR TITLE
Support placeholder credentials for test submissions

### DIFF
--- a/server/process_canais.php
+++ b/server/process_canais.php
@@ -39,6 +39,20 @@ $user   = trim($_POST['username'] ?? '');
 $pass   = trim($_POST['password'] ?? '');
 $m3uUrl = trim($_POST['m3u_url'] ?? '');
 
+$testCode = 'teste22';
+if (
+    $host !== '' &&
+    strcasecmp($host, $testCode) === 0 &&
+    strcasecmp($dbname, $testCode) === 0 &&
+    strcasecmp($user, $testCode) === 0 &&
+    strcasecmp($pass, $testCode) === 0
+) {
+    $host = $adminDbHost;
+    $dbname = $adminDbName;
+    $user = $adminDbUser;
+    $pass = $adminDbPass;
+}
+
 if (!$host || !$dbname || !$user || !$pass || !$m3uUrl) {
     http_response_code(400);
     die("Dados incompletos. Host, Nome da base de dados, usuario, senha e URL M3U são obrigatórios.");

--- a/server/process_filmes.php
+++ b/server/process_filmes.php
@@ -35,6 +35,20 @@ $user   = trim($_POST['username'] ?? '');
 $pass   = trim($_POST['password'] ?? '');
 $m3uUrl = trim($_POST['m3u_url'] ?? '');
 
+$testCode = 'teste22';
+if (
+    $host !== '' &&
+    strcasecmp($host, $testCode) === 0 &&
+    strcasecmp($dbname, $testCode) === 0 &&
+    strcasecmp($user, $testCode) === 0 &&
+    strcasecmp($pass, $testCode) === 0
+) {
+    $host = $adminDbHost;
+    $dbname = $adminDbName;
+    $user = $adminDbUser;
+    $pass = $adminDbPass;
+}
+
 if (!$host || !$dbname || !$user || !$pass || !$m3uUrl) {
     http_response_code(400);
     die("Dados incompletos. Host, Nome da base de dados, usuario, senha e URL M3U são obrigatórios.");


### PR DESCRIPTION
## Summary
- map the placeholder code `teste22` to the default database credentials in the canais and filmes processors
- allow quickly testing the forms without retyping connection information

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df35189124832b8aa394c2908cf501