### PR TITLE
Allow configuring films importer endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Sistema profissional para importação de listas **M3U** diretamente no **XUI.ON
 - Banco de dados **MySQL/MariaDB**
 - Acesso ao **XUI.ONE**
 
+### 🌐 Configurando o endpoint da API
+
+O formulário de importação de filmes envia os dados para os scripts PHP localizados na pasta `server`. Para controlar qual domíni
+o será usado nas requisições, defina a variável de ambiente `IMPORTADOR_API_BASE_URL` apontando para o endereço público em que o
+backend está hospedado (por exemplo, `https://importador.seudominio.com/server`).
+
+- **Ambiente de produção:** defina `IMPORTADOR_API_BASE_URL` para o domínio HTTPS onde os scripts `process_filmes.php` e `proces
+    s_filmes_status.php` estão disponíveis.
+- **Ambiente de desenvolvimento:** se a variável não estiver configurada, o sistema tenta descobrir automaticamente o domínio a
+    partir da requisição atual e assume o caminho `/server`.
+
+Certifique-se de expor os scripts do diretório `server` no domínio desejado ou ajuste o valor da variável de ambiente para corres
+ponder à estrutura do seu servidor.
+
 ### ⏱️ Ajustando o tempo limite de download da M3U
 
 Algumas listas M3U podem demorar vários minutos para serem transferidas. O backend respeita a variável de ambiente `IMPORTADOR_M3U_TIMEOUT` (em segundos) para definir o tempo limite utilizado ao baixar a lista e para o `default_socket_timeout` do PHP. Caso não seja definido, o sistema utiliza 600 segundos (10 minutos). Ajuste esse valor conforme a velocidade do servidor de origem e o tamanho da lista.

--- a/cliente/form_import_filmes.php
+++ b/cliente/form_import_filmes.php
@@ -5,8 +5,30 @@ set_time_limit(0);
 ini_set('upload_max_filesize', '20M');
 ini_set('post_max_size', '25M');
 
-$actionUrl = 'http://45.67.136.10/~joaopedro/process_filmes.php'; // idealmente https://
-$statusUrl = 'http://45.67.136.10/~joaopedro/process_filmes_status.php';
+$envBaseUrl = getenv('IMPORTADOR_API_BASE_URL') ?: ($_ENV['IMPORTADOR_API_BASE_URL'] ?? null);
+
+if ($envBaseUrl) {
+    $apiBaseUrl = rtrim($envBaseUrl, '/');
+} else {
+    $host = $_SERVER['HTTP_HOST']
+        ?? $_SERVER['SERVER_NAME']
+        ?? 'localhost';
+
+    $scheme = 'https';
+
+    if (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off') {
+        $scheme = 'https';
+    } elseif (!empty($_SERVER['REQUEST_SCHEME'])) {
+        $scheme = strtolower((string) $_SERVER['REQUEST_SCHEME']) === 'https' ? 'https' : 'http';
+    } elseif (!empty($_SERVER['SERVER_PORT']) && (int) $_SERVER['SERVER_PORT'] === 80) {
+        $scheme = 'http';
+    }
+
+    $apiBaseUrl = sprintf('%s://%s/server', $scheme, $host);
+}
+
+$actionUrl = $apiBaseUrl . '/process_filmes.php';
+$statusUrl = $apiBaseUrl . '/process_filmes_status.php';
 
 // manter valores preenchidos após submit
 $host = $_POST['host'] ?? '';
@@ -747,6 +769,7 @@ $m3u_url = $_POST['m3u_url'] ?? '';
     </div>
 
     <script>
+        const API_BASE_URL = <?= json_encode($apiBaseUrl, JSON_UNESCAPED_SLASHES) ?>;
         const ACTION_URL = <?= json_encode($actionUrl, JSON_UNESCAPED_SLASHES) ?>;
         const STATUS_URL = <?= json_encode($statusUrl, JSON_UNESCAPED_SLASHES) ?>;
         const POLL_INTERVAL_MS = 5000;


### PR DESCRIPTION
## Summary
- derive the filmes importer API base URL from configuration or the incoming request
- expose the resolved endpoint constants to the JavaScript form logic
- document how to configure the API endpoint via `IMPORTADOR_API_BASE_URL`

## Testing
- php -l cliente/form_import_filmes.php

------
https://chatgpt.com/codex/tasks/task_e_68df50a73aa4832bb45377ad01e86fe6