### PR TITLE
Fix Unicode handling for legendado regex in movie import

### DIFF
--- a/examples/import_filmes.php
+++ b/examples/import_filmes.php
@@ -51,7 +51,7 @@ function parseMovieTitle(string $rawName): array
     }
 
     // Normaliza indicações de legendado para um único [L]
-    $normalized = preg_replace('/(?:\s*[-\x{2013}\x{2014}]?\s*)?(?:\(|\[)?\s*(legendado|leg)\b\s*(?:\]|\))?/i', ' [L] ', $name);
+    $normalized = preg_replace('/(?:\s*[-\x{2013}\x{2014}]?\s*)?(?:\(|\[)?\s*(legendado|leg)\b\s*(?:\]|\))?/iu', ' [L] ', $name);
     $legendPattern = '/\s*(\(|\[)\s*(leg|l)\s*(\]|\))\s*/i';
     $normalized = preg_replace($legendPattern, ' [L] ', $normalized);
     $normalized = preg_replace('/\s+/', ' ', $normalized);

--- a/examples/import_series.php
+++ b/examples/import_series.php
@@ -51,7 +51,7 @@ function parseMovieTitle(string $rawName): array
     }
 
     // Normaliza indicações de legendado para um único [L]
-    $normalized = preg_replace('/(?:\s*[-\x{2013}\x{2014}]?\s*)?(?:\(|\[)?\s*(legendado|leg)\b\s*(?:\]|\))?/i', ' [L] ', $name);
+    $normalized = preg_replace('/(?:\s*[-\x{2013}\x{2014}]?\s*)?(?:\(|\[)?\s*(legendado|leg)\b\s*(?:\]|\))?/iu', ' [L] ', $name);
     $legendPattern = '/\s*(\(|\[)\s*(leg|l)\s*(\]|\))\s*/i';
     $normalized = preg_replace($legendPattern, ' [L] ', $normalized);
     $normalized = preg_replace('/\s+/', ' ', $normalized);

--- a/server/worker_process_filmes.php
+++ b/server/worker_process_filmes.php
@@ -102,7 +102,7 @@ function parseMovieTitle(string $rawName): array
         ];
     }
 
-    $normalized = preg_replace('/(?:\s*[-\x{2013}\x{2014}]?\s*)?(?:\(|\[)?\s*(legendado|leg)\b\s*(?:\]|\))?/i', ' [L] ', $name);
+    $normalized = preg_replace('/(?:\s*[-\x{2013}\x{2014}]?\s*)?(?:\(|\[)?\s*(legendado|leg)\b\s*(?:\]|\))?/iu', ' [L] ', $name);
     $legendPattern = '/\s*(\(|\[)\s*(leg|l)\s*(\]|\))\s*/i';
     $normalized = preg_replace($legendPattern, ' [L] ', $normalized);
     $normalized = preg_replace('/\s+/', ' ', $normalized);


### PR DESCRIPTION
## Summary
- add the Unicode modifier to the legendado normalization regex used during movie imports
- keep example import scripts aligned with the worker implementation

## Testing
- php -l server/worker_process_filmes.php
- php -l examples/import_filmes.php
- php -l examples/import_series.php

------
https://chatgpt.com/codex/tasks/task_e_68df5a72b5b0832b9fce38d7a897a025