### PR TITLE
Evitar duplicação dos totais exibidos no resumo de filmes

### DIFF
--- a/cliente/form_import_filmes.php
+++ b/cliente/form_import_filmes.php
@@ -961,7 +961,16 @@ $m3u_url = $_POST['m3u_url'] ?? '';
                         skipped: 'Filmes ignorados',
                         errors: 'Erros',
                     };
-                    totalsLines.push(`${labels[key]}: ${totals[key]}`);
+
+                    const label = labels[key];
+                    if (!label) {
+                        return;
+                    }
+
+                    const messageAlreadyHasLabel = typeof message === 'string' && message.includes(label);
+                    if (!messageAlreadyHasLabel) {
+                        totalsLines.push(`${label}: ${totals[key]}`);
+                    }
                 }
             });
 


### PR DESCRIPTION
## Summary
- evita adicionar novamente os totais de filmes adicionados, ignorados e erros quando já constam na mensagem retornada pelo servidor

## Testing
- não foram executados testes (não aplicável)


------
https://chatgpt.com/codex/tasks/task_e_68df61ad291c832b98e5640b85caca3a