### PR TITLE
Ocultar contagem de erros nas mensagens de importação

### DIFF
--- a/server/worker_process_canais.php
+++ b/server/worker_process_canais.php
@@ -373,7 +373,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     $summary .= "✅ Canais adicionados: {$totalAdded}\n";
     $summary .= "⚠️ Canais ignorados (duplicados): {$totalSkipped}\n";
     if ($totalErrors > 0) {
-        $summary .= "❌ Erros: {$totalErrors}\n";
+        $summary .= "❗ Ocorrências registradas durante a importação.\n";
     }
 
     return [

--- a/server/worker_process_filmes.php
+++ b/server/worker_process_filmes.php
@@ -643,7 +643,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
             } else {
                 $partialDetails[] = "Importação interrompida após confirmar {$confirmedProcessed} itens.";
             }
-            $partialDetails[] = "Adicionados: {$confirmedAdded}, ignorados: {$confirmedSkipped}, erros: {$confirmedErrors}.";
+            $partialDetails[] = "Adicionados: {$confirmedAdded}, ignorados: {$confirmedSkipped}.";
         }
         if ($lastPersistedCheckpoint !== null) {
             $partialDetails[] = 'Último checkpoint: ' . $lastPersistedCheckpoint . '.';
@@ -674,7 +674,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     $summaryLines[] = "➕ Filmes adicionados confirmados: {$confirmedAdded}";
     $summaryLines[] = "⏭️ Filmes ignorados (duplicados) confirmados: {$confirmedSkipped}";
     if ($confirmedErrors > 0) {
-        $summaryLines[] = "❌ Erros confirmados: {$confirmedErrors}";
+        $summaryLines[] = "❗ Ocorrências registradas durante a importação.";
     }
 
     $summary = implode("\n", $summaryLines) . "\n";


### PR DESCRIPTION
## Summary
- remover a referência direta a "erros:" quando a importação de canais é concluída
- atualizar o resumo e a mensagem de exceção da importação de filmes para não exibirem a contagem de erros

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dffe6e2100832bb439ef472f8d0a70