### PR TITLE
Fix default scheme detection for API proxy

### DIFF
--- a/cliente/api_proxy.php
+++ b/cliente/api_proxy.php
@@ -43,14 +43,14 @@ if ($apiBaseUrl === null) {
         ?? $_SERVER['SERVER_NAME']
         ?? 'localhost';
 
-    $scheme = 'https';
+    $scheme = 'http';
 
     if (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off') {
         $scheme = 'https';
     } elseif (!empty($_SERVER['REQUEST_SCHEME'])) {
         $scheme = strtolower((string) $_SERVER['REQUEST_SCHEME']) === 'https' ? 'https' : 'http';
-    } elseif (!empty($_SERVER['SERVER_PORT']) && (int) $_SERVER['SERVER_PORT'] === 80) {
-        $scheme = 'http';
+    } elseif (!empty($_SERVER['SERVER_PORT']) && (int) $_SERVER['SERVER_PORT'] === 443) {
+        $scheme = 'https';
     }
 
     $scriptPath = $_SERVER['SCRIPT_NAME'] ?? $_SERVER['PHP_SELF'] ?? '';


### PR DESCRIPTION
## Summary
- default the API proxy scheme to HTTP when the environment does not explicitly request HTTPS
- keep HTTPS detection when relevant server variables indicate a secure request

## Testing
- php -l cliente/api_proxy.php

------
https://chatgpt.com/codex/tasks/task_e_68e024a01540832b8cea30412e8e80f1