### PR TITLE
Fix status polling URL parameter handling

### DIFF
--- a/cliente/assets/importer.js
+++ b/cliente/assets/importer.js
@@ -238,7 +238,10 @@
 
         async function fetchStatus(jobId) {
             try {
-                const response = await fetch(`${statusUrl}?job_id=${encodeURIComponent(jobId)}`, {
+                const statusEndpoint = new URL(statusUrl, window.location.href);
+                statusEndpoint.searchParams.set('job_id', jobId);
+
+                const response = await fetch(statusEndpoint, {
                     cache: 'no-store'
                 });
 


### PR DESCRIPTION
## Summary
- ensure the status polling endpoint is built with URLSearchParams so job_id is appended correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e045f5f694832b94b8592968f2fcd8