### PR TITLE
Fix status polling URL construction

### DIFF
--- a/cliente/assets/importer.js
+++ b/cliente/assets/importer.js
@@ -236,10 +236,38 @@
             }
         }
 
+        function buildStatusEndpoint(jobId) {
+            if (!statusUrl) {
+                throw new Error('URL de status não configurada.');
+            }
+
+            const trimmedStatusUrl = statusUrl.trim();
+            const hashIndex = trimmedStatusUrl.indexOf('#');
+            const hash = hashIndex >= 0 ? trimmedStatusUrl.slice(hashIndex) : '';
+            const urlWithoutHash = hashIndex >= 0 ? trimmedStatusUrl.slice(0, hashIndex) : trimmedStatusUrl;
+
+            try {
+                const parsed = new URL(urlWithoutHash, window.location.href);
+                parsed.searchParams.set('job_id', jobId);
+                return `${parsed.toString()}${hash}`;
+            } catch (error) {
+                const questionMarkIndex = urlWithoutHash.indexOf('?');
+                const basePath = questionMarkIndex >= 0 ? urlWithoutHash.slice(0, questionMarkIndex) : urlWithoutHash;
+                const queryString = questionMarkIndex >= 0 ? urlWithoutHash.slice(questionMarkIndex + 1) : '';
+
+                const params = new URLSearchParams(queryString);
+                params.set('job_id', jobId);
+
+                const finalQuery = params.toString();
+                const separator = finalQuery ? '?' : '';
+
+                return `${basePath}${separator}${finalQuery}${hash}`;
+            }
+        }
+
         async function fetchStatus(jobId) {
             try {
-                const statusEndpoint = new URL(statusUrl, window.location.href);
-                statusEndpoint.searchParams.set('job_id', jobId);
+                const statusEndpoint = buildStatusEndpoint(jobId);
 
                 const response = await fetch(statusEndpoint, {
                     cache: 'no-store'


### PR DESCRIPTION
## Summary
- ensure the polling URL for job status always appends the job_id parameter correctly
- add a robust fallback for relative URLs, trimming hashes and stray whitespace before requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e048d85264832b99de271c32824c8d