### PR TITLE
Atualiza mensagem de status ao verificar lista M3U

### DIFF
--- a/server/worker_process_canais.php
+++ b/server/worker_process_canais.php
@@ -268,7 +268,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     updateJob($adminPdo, $jobId, [
         'm3u_file_path' => $fullPath,
         'progress' => CHANNEL_PROGRESS_DOWNLOAD,
-        'message' => 'Lista M3U baixada com sucesso. Conectando ao banco de destino...'
+        'message' => 'Lista M3U verfificada. Conectando ao banco de destino...'
     ]);
 
     try {

--- a/server/worker_process_filmes.php
+++ b/server/worker_process_filmes.php
@@ -391,7 +391,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     updateJob($adminPdo, $jobId, [
         'm3u_file_path' => $fullPath,
         'progress' => 5,
-        'message' => 'Lista M3U baixada com sucesso. Conectando ao banco de destino...'
+        'message' => 'Lista M3U verfificada. Conectando ao banco de destino...'
     ]);
 
     try {


### PR DESCRIPTION
## Summary
- atualiza o texto de status após o download da lista M3U informando que ela foi verificada antes de conectar ao banco de destino

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04ee47884832ba56249a55bf943fc