### PR TITLE
Ensure backend scripts load .env before using environment variables

### DIFF
--- a/server/process_canais.php
+++ b/server/process_canais.php
@@ -2,6 +2,59 @@
 
 declare(strict_types=1);
 
+if (!function_exists('importador_load_env')) {
+    function importador_load_env(): void
+    {
+        static $loaded = false;
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
+        $paths = [
+            __DIR__ . '/.env',
+            dirname(__DIR__) . '/.env',
+        ];
+
+        $seen = [];
+        foreach ($paths as $path) {
+            if (!is_string($path) || $path === '' || !is_file($path)) {
+                continue;
+            }
+            if (isset($seen[$path])) {
+                continue;
+            }
+            $seen[$path] = true;
+
+            $lines = @file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if ($lines === false) {
+                continue;
+            }
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line === '' || $line[0] === '#') {
+                    continue;
+                }
+                if (strpos($line, '=') === false) {
+                    continue;
+                }
+
+                [$name, $value] = array_map('trim', explode('=', $line, 2));
+                if ($name === '') {
+                    continue;
+                }
+
+                putenv("{$name}={$value}");
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+            }
+        }
+    }
+}
+
+importador_load_env();
+
 set_time_limit(0);
 
 function sendJsonResponse(array $payload, int $statusCode = 200): void

--- a/server/process_filmes.php
+++ b/server/process_filmes.php
@@ -2,6 +2,59 @@
 
 declare(strict_types=1);
 
+if (!function_exists('importador_load_env')) {
+    function importador_load_env(): void
+    {
+        static $loaded = false;
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
+        $paths = [
+            __DIR__ . '/.env',
+            dirname(__DIR__) . '/.env',
+        ];
+
+        $seen = [];
+        foreach ($paths as $path) {
+            if (!is_string($path) || $path === '' || !is_file($path)) {
+                continue;
+            }
+            if (isset($seen[$path])) {
+                continue;
+            }
+            $seen[$path] = true;
+
+            $lines = @file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if ($lines === false) {
+                continue;
+            }
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line === '' || $line[0] === '#') {
+                    continue;
+                }
+                if (strpos($line, '=') === false) {
+                    continue;
+                }
+
+                [$name, $value] = array_map('trim', explode('=', $line, 2));
+                if ($name === '') {
+                    continue;
+                }
+
+                putenv("{$name}={$value}");
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+            }
+        }
+    }
+}
+
+importador_load_env();
+
 set_time_limit(0);
 
 function sendJsonResponse(array $payload, int $statusCode = 200): void

--- a/server/worker_process_canais.php
+++ b/server/worker_process_canais.php
@@ -2,6 +2,60 @@
 
 declare(strict_types=1);
 
+// --- Loader manual do .env ---
+if (!function_exists('importador_load_env')) {
+    function importador_load_env(): void
+    {
+        static $loaded = false;
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
+        $paths = [
+            __DIR__ . '/.env',
+            dirname(__DIR__) . '/.env',
+        ];
+
+        $seen = [];
+        foreach ($paths as $path) {
+            if (!is_string($path) || $path === '' || !is_file($path)) {
+                continue;
+            }
+            if (isset($seen[$path])) {
+                continue;
+            }
+            $seen[$path] = true;
+
+            $lines = @file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if ($lines === false) {
+                continue;
+            }
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line === '' || $line[0] === '#') {
+                    continue;
+                }
+                if (strpos($line, '=') === false) {
+                    continue;
+                }
+
+                [$name, $value] = array_map('trim', explode('=', $line, 2));
+                if ($name === '') {
+                    continue;
+                }
+
+                putenv("{$name}={$value}");
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+            }
+        }
+    }
+}
+
+importador_load_env();
+
 set_time_limit(0);
 
 const CHANNEL_PROGRESS_START = 10;

--- a/server/worker_process_filmes.php
+++ b/server/worker_process_filmes.php
@@ -2,6 +2,59 @@
 
 declare(strict_types=1);
 
+if (!function_exists('importador_load_env')) {
+    function importador_load_env(): void
+    {
+        static $loaded = false;
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
+        $paths = [
+            __DIR__ . '/.env',
+            dirname(__DIR__) . '/.env',
+        ];
+
+        $seen = [];
+        foreach ($paths as $path) {
+            if (!is_string($path) || $path === '' || !is_file($path)) {
+                continue;
+            }
+            if (isset($seen[$path])) {
+                continue;
+            }
+            $seen[$path] = true;
+
+            $lines = @file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if ($lines === false) {
+                continue;
+            }
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line === '' || $line[0] === '#') {
+                    continue;
+                }
+                if (strpos($line, '=') === false) {
+                    continue;
+                }
+
+                [$name, $value] = array_map('trim', explode('=', $line, 2));
+                if ($name === '') {
+                    continue;
+                }
+
+                putenv("{$name}={$value}");
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+            }
+        }
+    }
+}
+
+importador_load_env();
+
 set_time_limit(0);
 
 const SUPPORTED_TARGET_CONTAINERS = ['mp4', 'mkv', 'avi', 'mpg', 'flv', '3gp', 'm4v', 'wmv', 'mov', 'ts'];


### PR DESCRIPTION
## Summary
- add a reusable importador_load_env helper in the backend scripts to load .env files before getenv usage
- ensure both process and worker scripts share the same loader so IMPORTADOR_M3U_TIMEOUT and other env vars are available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e04fac4438832b919c1831066e4eb2