### PR TITLE
Atualiza textos sobre fontes nos formulários

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📦 Importador M3U para XUI.ONE
 
-Sistema profissional para importação de listas **M3U** diretamente no **XUI.ONE**, com categorização automática e prevenção de duplicados.
+Sistema profissional para importação de Fonte de listas **M3U** diretamente no **XUI.ONE**, com categorização automática e prevenção de duplicados.
 
 ## 🚀 Estrutura do Projeto
 

--- a/cliente/form_import_canais.php
+++ b/cliente/form_import_canais.php
@@ -580,7 +580,7 @@ $m3u_url = $_POST['m3u_url'] ?? '';
     <div class="container">
         <header class="header">
             <h1><i class="fas fa-cloud-upload-alt"></i> Importador M3U</h1>
-            <p>Sistema profissional para importação de <span style="background:#fff3b0;color: #000;">CANAIS</span> da listas M3U diretamente para o <strong>XUI.ONE</strong>, com categorização automática.</p>
+            <p>Sistema profissional para importação de Fonte de <span style="background:#fff3b0;color: #000;">CANAIS</span> diretamente para o <strong>XUI.ONE</strong>, com categorização automática.</p>
         </header>
 
         <main class="main-card">
@@ -644,7 +644,7 @@ $m3u_url = $_POST['m3u_url'] ?? '';
                     <div class="form-group">
                         <label for="m3u_url">
                             <i class="fas fa-link"></i>
-                            URL da Lista M3U
+                            URL da Fonte
                         </label>
                         <input type="url" 
                                id="m3u_url" 

--- a/cliente/form_import_filmes.php
+++ b/cliente/form_import_filmes.php
@@ -580,7 +580,7 @@ $m3u_url = $_POST['m3u_url'] ?? '';
     <div class="container">
         <header class="header">
             <h1><i class="fas fa-cloud-upload-alt"></i> Importador M3U</h1>
-            <p>Sistema profissional para importação de <span style="background:#fff3b0;color: #000;">FILMES</span> da listas M3U diretamente para o <strong>XUI.ONE</strong>, com categorização automática.</p>
+            <p>Sistema profissional para importação de Fonte de <span style="background:#fff3b0;color: #000;">FILMES</span> diretamente para o <strong>XUI.ONE</strong>, com categorização automática.</p>
         </header>
 
         <main class="main-card">
@@ -644,7 +644,7 @@ $m3u_url = $_POST['m3u_url'] ?? '';
                     <div class="form-group">
                         <label for="m3u_url">
                             <i class="fas fa-link"></i>
-                            URL da Lista M3U
+                            URL da Fonte
                         </label>
                         <input type="url" 
                                id="m3u_url" 


### PR DESCRIPTION
## Summary
- atualizar o texto principal das páginas de importação de canais e filmes para falar em "Fonte"
- renomear o campo de URL das páginas de importação para "URL da Fonte"
- alinhar a descrição inicial do README com a nova nomenclatura

## Testing
- não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68e07fcd5cbc832bae10b8a8922cd5e1