### PR TITLE
Implement series import workflow

### DIFF
--- a/cliente/api_proxy.php
+++ b/cliente/api_proxy.php
@@ -59,6 +59,8 @@ $endpointMap = [
     'canais_status' => 'process_canais_status.php',
     'filmes'        => 'process_filmes.php',
     'filmes_status' => 'process_filmes_status.php',
+    'series'        => 'process_series.php',
+    'series_status' => 'process_series_status.php',
 ];
 
 if (!array_key_exists($endpointKey, $endpointMap)) {

--- a/cliente/form_import_series.php
+++ b/cliente/form_import_series.php
@@ -1,0 +1,867 @@
+<?php
+// configs iniciais
+ini_set('memory_limit', '512M');
+set_time_limit(0);
+ini_set('upload_max_filesize', '20M');
+ini_set('post_max_size', '25M');
+
+$buildLocalUrl = static function (string $script, array $params = []): string {
+    $scriptPath = $_SERVER['SCRIPT_NAME'] ?? $_SERVER['PHP_SELF'] ?? '';
+    $directory = str_replace('\\', '/', dirname($scriptPath));
+
+    if ($directory === '/' || $directory === '\\' || $directory === '.') {
+        $directory = '';
+    } else {
+        $directory = rtrim($directory, '/');
+    }
+
+    $url = ($directory === '' ? '' : $directory) . '/' . ltrim($script, '/');
+
+    if (!empty($params)) {
+        $queryString = http_build_query($params);
+        if ($queryString !== '') {
+            $url .= '?' . $queryString;
+        }
+    }
+
+    return $url;
+};
+
+$actionUrl = $buildLocalUrl('api_proxy.php', ['endpoint' => 'series']);
+$statusUrl = $buildLocalUrl('api_proxy.php', ['endpoint' => 'series_status']);
+
+// manter valores preenchidos após submit
+$host = $_POST['host'] ?? '';
+$dbname = $_POST['dbname'] ?? 'xui';
+$username = $_POST['username'] ?? '';
+$password = $_POST['password'] ?? '';
+$m3u_url = $_POST['m3u_url'] ?? '';
+?>
+<!DOCTYPE html>
+<html lang="pt-PT">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Importador M3U para XUI.ONE</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --primary-color: #3b82f6;
+            --primary-hover: #2563eb;
+            --primary-light: #dbeafe;
+            --secondary-color: #64748b;
+            --success-color: #10b981;
+            --error-color: #ef4444;
+            --warning-color: #f59e0b;
+            --bg-primary: #0f172a;
+            --bg-secondary: #1e293b;
+            --bg-tertiary: #334155;
+            --text-primary: #f8fafc;
+            --text-secondary: #cbd5e1;
+            --text-muted: #94a3b8;
+            --border-color: #475569;
+            --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+            --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+            --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+            --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+            --radius-sm: 0.375rem;
+            --radius-md: 0.5rem;
+            --radius-lg: 0.75rem;
+            --radius-xl: 1rem;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, var(--bg-primary) 0%, #1a202c 100%);
+            color: var(--text-primary);
+            line-height: 1.6;
+            min-height: 100vh;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 3rem;
+        }
+
+        .header h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            background: linear-gradient(135deg, var(--primary-color), #8b5cf6);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            margin-bottom: 1rem;
+        }
+
+        .header p {
+            font-size: 1.125rem;
+            color: var(--text-secondary);
+            max-width: 600px;
+            margin: 0 auto;
+        }
+
+        .main-card {
+            background: var(--bg-secondary);
+            border-radius: var(--radius-xl);
+            box-shadow: var(--shadow-xl);
+            border: 1px solid var(--border-color);
+            overflow: hidden;
+            margin-bottom: 2rem;
+        }
+
+        .card-header {
+            background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
+            padding: 1.5rem 2rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .card-header h2 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: white;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .form-container {
+            padding: 2rem;
+        }
+
+        .form-grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        .form-group {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .form-group label {
+            font-weight: 500;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .form-group label i {
+            color: var(--primary-color);
+            width: 16px;
+        }
+
+        .input-wrapper {
+            position: relative;
+        }
+
+        .form-group input {
+            width: 100%;
+            padding: 0.875rem 1rem;
+            background: var(--bg-tertiary);
+            border: 2px solid var(--border-color);
+            border-radius: var(--radius-md);
+            color: var(--text-primary);
+            font-size: 1rem;
+            transition: all 0.2s ease;
+        }
+
+        .form-group input:focus {
+            outline: none;
+            border-color: var(--primary-color);
+            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+        }
+
+        .form-group input::placeholder {
+            color: var(--text-muted);
+        }
+
+        .submit-btn {
+            background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
+            color: white;
+            border: none;
+            padding: 1rem 2rem;
+            border-radius: var(--radius-md);
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .submit-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-lg);
+        }
+
+        .submit-btn:active {
+            transform: translateY(0);
+        }
+
+        .response-container {
+            margin-top: 2rem;
+            margin-bottom: 2rem; /* Adicionado para espaçamento com a seção FAQ */
+        }
+
+        .response-box {
+            background: var(--bg-secondary);
+            border-radius: var(--radius-xl);
+            padding: 0;
+            box-shadow: var(--shadow-xl);
+            border: 1px solid var(--border-color);
+            overflow: hidden;
+        }
+
+        .response-header {
+            background: linear-gradient(135deg, var(--error-color), #dc2626);
+            padding: 1rem 1.5rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .response-header.success {
+            background: linear-gradient(135deg, var(--success-color), #059669);
+        }
+
+        .response-header.warning {
+            background: linear-gradient(135deg, var(--warning-color), #d97706);
+        }
+
+        .response-header h3 {
+            font-size: 1rem;
+            font-weight: 600;
+            color: white;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin: 0;
+        }
+
+        .response-content {
+            padding: 1.5rem;
+            font-family: 'Inter', sans-serif;
+            font-size: 0.95rem;
+            line-height: 1.6;
+            color: var(--text-primary);
+        }
+
+        .response-content .message-line {
+            margin-bottom: 0.75rem;
+            padding: 0.5rem 0;
+        }
+
+        .response-content .message-line:last-child {
+            margin-bottom: 0;
+        }
+
+        .response-content .error-detail {
+            background: rgba(239, 68, 68, 0.1);
+            border: 1px solid rgba(239, 68, 68, 0.3);
+            border-radius: var(--radius-md);
+            padding: 1rem;
+            margin-top: 1rem;
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+        }
+
+        .response-content .success-detail {
+            background: rgba(16, 185, 129, 0.1);
+            border: 1px solid rgba(16, 185, 129, 0.3);
+            border-radius: var(--radius-md);
+            padding: 1rem;
+            margin-top: 1rem;
+        }
+
+        .progress-wrapper {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            margin-bottom: 1rem;
+        }
+
+        .progress-bar {
+            width: 100%;
+            height: 12px;
+            background: rgba(59, 130, 246, 0.15);
+            border-radius: var(--radius-md);
+            overflow: hidden;
+            border: 1px solid rgba(59, 130, 246, 0.35);
+        }
+
+        .progress-bar-fill {
+            height: 100%;
+            width: 0%;
+            background: linear-gradient(135deg, var(--primary-color), var(--primary-hover));
+            transition: width 0.3s ease;
+        }
+
+        .progress-text {
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+            text-align: right;
+        }
+
+        .message-lines {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            white-space: pre-line;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        .faq-section {
+            background: var(--bg-secondary);
+            border-radius: var(--radius-xl);
+            box-shadow: var(--shadow-xl);
+            border: 1px solid var(--border-color);
+            overflow: hidden;
+        }
+
+        .faq-header {
+            background: linear-gradient(135deg, var(--secondary-color), #475569);
+            padding: 1.5rem 2rem;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .faq-header h2 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: white;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .faq-content {
+            padding: 1rem;
+        }
+
+        .faq-item {
+            border-bottom: 1px solid var(--border-color);
+            margin-bottom: 0;
+        }
+
+        .faq-item:last-child {
+            border-bottom: none;
+        }
+
+        .faq-question {
+            background: transparent;
+            border: none;
+            width: 100%;
+            text-align: left;
+            padding: 1.25rem;
+            font-size: 1rem;
+            font-weight: 500;
+            color: var(--text-primary);
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: between;
+            gap: 1rem;
+            transition: all 0.2s ease;
+        }
+
+        .faq-question:hover {
+            background: var(--bg-tertiary);
+        }
+
+        .faq-question i {
+            color: var(--primary-color);
+            transition: transform 0.2s ease;
+            margin-left: auto;
+        }
+
+        .faq-question.active i {
+            transform: rotate(180deg);
+        }
+
+        .faq-answer {
+            padding: 0 1.25rem 1.25rem;
+            color: var(--text-secondary);
+            display: none;
+            animation: fadeIn 0.3s ease;
+        }
+
+        .faq-answer.active {
+            display: block;
+        }
+
+        .faq-answer pre {
+            background: var(--bg-primary);
+            color: var(--success-color);
+            padding: 1rem;
+            border-radius: var(--radius-md);
+            overflow-x: auto;
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+            margin: 1rem 0;
+            border: 1px solid var(--border-color);
+        }
+
+        .faq-answer code {
+            background: var(--bg-tertiary);
+            color: var(--primary-color);
+            padding: 0.25rem 0.5rem;
+            border-radius: var(--radius-sm);
+            font-family: 'Courier New', monospace;
+            font-size: 0.875rem;
+        }
+
+        .highlight-box {
+            background: linear-gradient(135deg, rgba(59, 130, 246, 0.1), rgba(139, 92, 246, 0.1));
+            border: 1px solid var(--primary-color);
+            border-radius: var(--radius-lg);
+            padding: 1.5rem;
+            margin: 1rem 0;
+        }
+
+        .highlight-box .meg {
+            background: transparent;
+            border: none;
+            width: 100%;
+            text-align: left;
+            padding: 0;
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--primary-color);
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .highlight-box .meg:hover {
+            color: var(--primary-hover);
+        }
+
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(-10px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        /* Responsividade aprimorada */
+        @media (max-width: 768px) {
+            .container {
+                padding: 1rem;
+            }
+
+            .header h1 {
+                font-size: 2rem;
+            }
+
+            .header p {
+                font-size: 1rem;
+            }
+
+            .form-container {
+                padding: 1.5rem;
+            }
+
+            .card-header,
+            .faq-header {
+                padding: 1rem 1.5rem;
+            }
+
+            .faq-question {
+                padding: 1rem;
+                font-size: 0.9rem;
+            }
+
+            .faq-answer {
+                padding: 0 1rem 1rem;
+            }
+
+            .submit-btn {
+                padding: 0.875rem 1.5rem;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .container {
+                padding: 0.5rem;
+            }
+
+            .header {
+                margin-bottom: 2rem;
+            }
+
+            .header h1 {
+                font-size: 1.75rem;
+            }
+
+            .form-container {
+                padding: 1rem;
+            }
+
+            .card-header,
+            .faq-header {
+                padding: 1rem;
+            }
+
+            .card-header h2,
+            .faq-header h2 {
+                font-size: 1.125rem;
+            }
+
+            .faq-question {
+                padding: 0.875rem;
+                font-size: 0.875rem;
+            }
+
+            .faq-answer {
+                padding: 0 0.875rem 0.875rem;
+                font-size: 0.875rem;
+            }
+
+            .form-group input {
+                padding: 0.75rem;
+            }
+
+            .submit-btn {
+                padding: 0.75rem 1.25rem;
+                font-size: 0.9rem;
+            }
+        }
+
+        /* Melhorias de acessibilidade */
+        .form-group input:invalid {
+            border-color: var(--error-color);
+        }
+
+        .form-group input:valid {
+            border-color: var(--success-color);
+        }
+
+        /* Loading state */
+        .submit-btn:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            transform: none;
+        }
+
+        .loading {
+            display: inline-block;
+            width: 16px;
+            height: 16px;
+            border: 2px solid transparent;
+            border-top: 2px solid currentColor;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header class="header">
+            <h1><i class="fas fa-cloud-upload-alt"></i> Importador M3U</h1>
+            <p>Sistema profissional para importação de Fonte de <span style="background:#fff3b0;color: #000;">SÉRIES E EPISÓDIOS</span> diretamente para o <strong>XUI.ONE</strong>, com categorização automática e vinculação das temporadas.</p>
+        </header>
+
+        <main class="main-card">
+            <div class="card-header">
+                <h2><i class="fas fa-database"></i> Configuração do Sistema</h2>
+            </div>
+            <div class="form-container">
+                <form method="post" autocomplete="off" class="form-grid" id="importForm">
+                    <div class="form-group">
+                        <label for="host">
+                            <i class="fas fa-server"></i>
+                            Endereço IP do Banco de Dados
+                        </label>
+                        <input type="text"
+                               id="host"
+                               name="host"
+                               required
+                               value="<?= htmlspecialchars($host) ?>"
+                               placeholder="Ex: 192.168.1.100">
+                    </div>
+
+                    <div class="form-group hidden">
+                        <label for="dbname">
+                            <i class="fas fa-database"></i>
+                            Nome do Banco de Dados
+                        </label>
+                        <input type="text"
+                               id="dbname"
+                               name="dbname"
+                               value="xui"
+                               required
+                               placeholder="Ex: xui">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="username">
+                            <i class="fas fa-user"></i>
+                            Usuário do Banco de Dados
+                        </label>
+                        <input type="text"
+                               id="username"
+                               name="username"
+                               required
+                               value="<?= htmlspecialchars($username) ?>"
+                               placeholder="Ex: admin">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="password">
+                            <i class="fas fa-lock"></i>
+                            Senha do Banco de Dados
+                        </label>
+                        <input type="password"
+                               id="password"
+                               name="password"
+                               required
+                               value="<?= htmlspecialchars($password) ?>"
+                               placeholder="Digite a senha">
+                    </div>
+
+                    <div class="form-group">
+                        <label for="m3u_url">
+                            <i class="fas fa-link"></i>
+                            URL da Fonte
+                        </label>
+                        <input type="url" 
+                               id="m3u_url" 
+                               name="m3u_url" 
+                               required 
+                               value="<?= htmlspecialchars($m3u_url) ?>"
+                               placeholder="https://exemplo.com/lista.m3u">
+                    </div>
+
+                    <button type="submit" class="submit-btn" id="submitBtn">
+                        <i class="fas fa-upload"></i>
+                        Iniciar Importação
+                    </button>
+                </form>
+            </div>
+        </main>
+
+        <div class="response-container">
+            <div id="responseBox" class="response-box hidden">
+                <div id="responseHeader" class="response-header warning">
+                    <h3>
+                        <i id="responseIcon" class="fas fa-circle-info"></i>
+                        <span id="responseTitle">Resultado da Importação</span>
+                    </h3>
+                </div>
+
+                <div class="response-content">
+                    <div id="progressWrapper" class="progress-wrapper hidden">
+                        <div class="progress-bar">
+                            <div id="progressBar" class="progress-bar-fill"></div>
+                        </div>
+                        <div id="progressText" class="progress-text">0%</div>
+                    </div>
+                    <div id="responseMessage" class="message-lines"></div>
+                </div>
+            </div>
+        </div>
+
+        <section class="faq-section">
+            <div class="faq-header">
+                <h2><i class="fas fa-question-circle"></i> Perguntas Frequentes</h2>
+            </div>
+            <div class="faq-content">
+                <div class="faq-item">
+                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
+                        Como criar um usuário no banco de dados?
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <p><strong>Siga estes passos para criar um novo usuário no seu banco de dados:</strong></p>
+                        
+                        <p><strong>1.</strong> Acesse sua máquina do <strong>XUI.ONE</strong> via terminal.</p>
+                        
+                        <p><strong>2.</strong> Execute o seguinte comando SQL para acessar o MySQL:</p>
+                        <pre><code>mysql -u root -p</code></pre>
+
+                        <p><strong>3.</strong> Crie o usuário e senha desejados:</p>
+                        <pre><code>CREATE USER 'novo_usuario'@'%' IDENTIFIED BY 'senha_segura';</code></pre>
+
+                        <p><strong>4.</strong> Conceda privilégios ao usuário:</p>
+                        <pre><code>GRANT ALL PRIVILEGES ON *.* TO 'novo_usuario'@'%';</code></pre>
+
+                        <p><strong>5.</strong> Aplique as alterações:</p>
+                        <pre><code>FLUSH PRIVILEGES;</code></pre>
+                        
+                        <p><strong>Nota:</strong> Substitua <code>'novo_usuario'</code> e <code>'senha_segura'</code> pelos valores apropriados.</p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
+                        O que faz esse sistema?
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <p>É um importador profissional de listas de séries para o <strong>XUI.ONE</strong>. O sistema também cadastra automaticamente as categorias correspondentes, cria as séries e relaciona cada episódio, evitando duplicações e garantindo uma importação limpa e organizada.</p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
+                        O que acontece se informar dados incorretos?
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <p>O sistema identifica automaticamente os erros e exibe mensagens claras, tais como:</p>
+                        <ul>
+                            <li>Usuário ou senha incorretos</li>
+                            <li>Banco de dados inexistente</li>
+                            <li>Falha de conexão com o servidor</li>
+                            <li>URL M3U inválida ou inacessível</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
+                        Como sei se a lista foi importada com sucesso?
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <p>Ao final do processo, o sistema apresenta um resumo detalhado com:</p>
+                        <ul>
+                            <li>Número de episódios adicionados com sucesso</li>
+                            <li>Episódios ignorados por já existirem</li>
+                            <li>Eventuais erros encontrados durante o processo</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
+                        O sistema altera ou remove dados existentes?
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <p><strong>Não.</strong> O importador apenas <strong>insere</strong> novas categorias, séries e episódios. O sistema não possui permissões para alterar ou remover dados existentes, garantindo a segurança do seu banco de dados.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+
+    <script src="assets/importer.js"></script>
+    <script>
+        const ACTION_URL = <?= json_encode($actionUrl, JSON_UNESCAPED_SLASHES) ?>;
+        const STATUS_URL = <?= json_encode($statusUrl, JSON_UNESCAPED_SLASHES) ?>;
+        const form = document.getElementById('importForm');
+        const submitBtn = document.getElementById('submitBtn');
+        createImportJobController({
+            form,
+            submitButton: submitBtn,
+            elements: {
+                responseBox: document.getElementById('responseBox'),
+                responseHeader: document.getElementById('responseHeader'),
+                responseIcon: document.getElementById('responseIcon'),
+                responseTitle: document.getElementById('responseTitle'),
+                responseMessage: document.getElementById('responseMessage'),
+                progressWrapper: document.getElementById('progressWrapper'),
+                progressBar: document.getElementById('progressBar'),
+                progressText: document.getElementById('progressText'),
+            },
+            urls: {
+                action: ACTION_URL,
+                status: STATUS_URL,
+            },
+            stateTitles: {
+                running: 'Processando séries e episódios',
+            },
+            messages: {
+                running: 'Processando séries e episódios...',
+            },
+            totalsLabels: {
+                added: 'Episódios adicionados',
+                skipped: 'Episódios ignorados',
+                errors: 'Ocorrências',
+            },
+        });
+
+        // Funcionalidade FAQ melhorada
+        function toggleFaq(element) {
+            const answer = element.nextElementSibling;
+            const icon = element.querySelector('i:last-child');
+
+            document.querySelectorAll('.faq-question').forEach(q => {
+                if (q !== element) {
+                    q.classList.remove('active');
+                    q.nextElementSibling.classList.remove('active');
+                    q.querySelector('i:last-child').style.transform = 'rotate(0deg)';
+                }
+            });
+
+            element.classList.toggle('active');
+            answer.classList.toggle('active');
+
+            if (element.classList.contains('active')) {
+                icon.style.transform = 'rotate(180deg)';
+            } else {
+                icon.style.transform = 'rotate(0deg)';
+            }
+        }
+
+        // Funcionalidade para o destaque especial
+        function toggleContent(element) {
+            const content = element.nextElementSibling;
+            const icon = element.querySelector('i:last-child');
+
+            content.classList.toggle('active');
+
+            if (content.classList.contains('active')) {
+                content.style.display = 'block';
+                icon.style.transform = 'rotate(180deg)';
+            } else {
+                content.style.display = 'none';
+                icon.style.transform = 'rotate(0deg)';
+            }
+        }
+
+        // Validação em tempo real
+        document.querySelectorAll('input[required]').forEach(input => {
+            input.addEventListener('blur', function() {
+                if (this.value.trim() === '') {
+                    this.style.borderColor = 'var(--error-color)';
+                } else {
+                    this.style.borderColor = 'var(--success-color)';
+                }
+            });
+        });
+
+        document.getElementById('m3u_url').addEventListener('input', function() {
+            const urlPattern = /^https?:\/\/.+/;
+            if (this.value && !urlPattern.test(this.value)) {
+                this.style.borderColor = 'var(--error-color)';
+            } else if (this.value) {
+                this.style.borderColor = 'var(--success-color)';
+            }
+        });
+    </script>
+</body>
+</html>

--- a/server/process_series.php
+++ b/server/process_series.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('importador_load_env')) {
+    function importador_load_env(): void
+    {
+        static $loaded = false;
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
+        $paths = [
+            __DIR__ . '/.env',
+            dirname(__DIR__) . '/.env',
+        ];
+
+        $seen = [];
+        foreach ($paths as $path) {
+            if (!is_string($path) || $path === '' || !is_file($path)) {
+                continue;
+            }
+            if (isset($seen[$path])) {
+                continue;
+            }
+            $seen[$path] = true;
+
+            $lines = @file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if ($lines === false) {
+                continue;
+            }
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line === '' || $line[0] === '#') {
+                    continue;
+                }
+                if (strpos($line, '=') === false) {
+                    continue;
+                }
+
+                [$name, $value] = array_map('trim', explode('=', $line, 2));
+                if ($name === '') {
+                    continue;
+                }
+
+                putenv("{$name}={$value}");
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+            }
+        }
+    }
+}
+
+importador_load_env();
+
+set_time_limit(0);
+
+function sendJsonResponse(array $payload, int $statusCode = 200): void
+{
+    http_response_code($statusCode);
+    header('Content-Type: application/json; charset=utf-8');
+    header('Access-Control-Allow-Origin: *');
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+function triggerBackgroundWorker(string $workerScript, int $jobId): void
+{
+    if ($jobId <= 0) {
+        return;
+    }
+
+    $scriptPath = realpath(__DIR__ . '/' . ltrim($workerScript, '/'));
+    if ($scriptPath === false) {
+        return;
+    }
+
+    $phpBinary = PHP_BINARY !== '' ? PHP_BINARY : 'php';
+    $phpBinaryBasename = basename($phpBinary);
+    $shouldSwitchToCli = PHP_SAPI !== 'cli' || ($phpBinaryBasename !== '' && stripos($phpBinaryBasename, 'php-fpm') !== false);
+
+    if ($shouldSwitchToCli) {
+        $cliCandidates = [];
+        $envCli = getenv('IMPORTADOR_PHP_CLI');
+        if (is_string($envCli) && $envCli !== '') {
+            $cliCandidates[] = $envCli;
+        }
+
+        if (defined('PHP_BINDIR')) {
+            $cliCandidates[] = rtrim(PHP_BINDIR, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'php';
+        }
+
+        $cliCandidates[] = 'php';
+
+        foreach ($cliCandidates as $candidate) {
+            if ($candidate === '') {
+                continue;
+            }
+
+            if ($candidate === 'php') {
+                $phpBinary = $candidate;
+                break;
+            }
+
+            if (@is_executable($candidate)) {
+                $phpBinary = $candidate;
+                break;
+            }
+        }
+    }
+
+    $command = escapeshellarg($phpBinary) . ' ' . escapeshellarg($scriptPath) . ' ' . $jobId;
+
+    if (stripos(PHP_OS, 'WIN') === 0) {
+        if (function_exists('popen') && function_exists('pclose')) {
+            @pclose(@popen('start /B ' . $command, 'r'));
+        }
+        return;
+    }
+
+    $backgroundCommand = $command . ' > /dev/null 2>&1 &';
+
+    if (function_exists('exec')) {
+        @exec($backgroundCommand);
+        return;
+    }
+
+    if (function_exists('shell_exec')) {
+        @shell_exec($backgroundCommand);
+    }
+}
+
+$timeoutEnv = getenv('IMPORTADOR_M3U_TIMEOUT');
+if ($timeoutEnv !== false && is_numeric($timeoutEnv) && (int) $timeoutEnv > 0) {
+    $streamTimeout = (int) $timeoutEnv;
+} else {
+    $streamTimeout = 600;
+}
+
+ini_set('default_socket_timeout', (string) $streamTimeout);
+
+$adminDbHost = '127.0.0.1';
+$adminDbName = 'joaopedro_xui';
+$adminDbUser = 'joaopedro_user';
+$adminDbPass = 'd@z[VGxj)~FNCft6';
+
+try {
+    $adminPdo = new PDO(
+        "mysql:host={$adminDbHost};dbname={$adminDbName};charset=utf8mb4",
+        $adminDbUser,
+        $adminDbPass,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+} catch (PDOException $e) {
+    sendJsonResponse(['error' => 'Erro no servidor: ' . $e->getMessage()], 500);
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    sendJsonResponse(['error' => 'Método inválido. Utilize POST.'], 405);
+}
+
+$host   = trim($_POST['host'] ?? '');
+$dbname = trim($_POST['dbname'] ?? '');
+$user   = trim($_POST['username'] ?? '');
+$pass   = trim($_POST['password'] ?? '');
+$m3uUrl = trim($_POST['m3u_url'] ?? '');
+
+$testCode = 'teste22';
+if (
+    $host !== '' &&
+    strcasecmp($host, $testCode) === 0 &&
+    strcasecmp($dbname, $testCode) === 0 &&
+    strcasecmp($user, $testCode) === 0 &&
+    strcasecmp($pass, $testCode) === 0
+) {
+    $host = $adminDbHost;
+    $dbname = $adminDbName;
+    $user = $adminDbUser;
+    $pass = $adminDbPass;
+}
+
+if ($host === '' || $dbname === '' || $user === '' || $pass === '' || $m3uUrl === '') {
+    sendJsonResponse(['error' => 'Dados incompletos. Host, Nome da base de dados, usuário, senha e URL M3U são obrigatórios.'], 400);
+}
+
+if (!filter_var($m3uUrl, FILTER_VALIDATE_URL)) {
+    sendJsonResponse(['error' => 'URL M3U inválida.'], 400);
+}
+
+try {
+    new PDO(
+        "mysql:host={$host};dbname={$dbname};charset=utf8mb4",
+        $user,
+        $pass,
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ]
+    );
+} catch (PDOException $e) {
+    $msg = $e->getMessage();
+
+    try {
+        $errorStmt = $adminPdo->prepare('
+            INSERT INTO clientes_import_jobs (
+                job_type,
+                db_host,
+                db_name,
+                db_user,
+                db_password,
+                m3u_url,
+                status,
+                progress,
+                message
+            ) VALUES (
+                :job_type,
+                :host,
+                :dbname,
+                :user,
+                :pass,
+                :m3u_url,
+                :status,
+                :progress,
+                :message
+            )
+        ');
+
+        $errorStmt->execute([
+            ':job_type' => 'series',
+            ':host' => $host,
+            ':dbname' => $dbname,
+            ':user' => $user,
+            ':pass' => $pass,
+            ':m3u_url' => $m3uUrl,
+            ':status' => 'failed',
+            ':progress' => 0,
+            ':message' => 'Falha ao validar conexão: ' . $msg,
+        ]);
+    } catch (PDOException $logException) {
+        // Ignorado para não sobrescrever a resposta original ao usuário.
+    }
+
+    if (str_contains($msg, 'Access denied')) {
+        sendJsonResponse(['error' => 'Usuário ou senha incorretos para o banco de dados informado.'], 401);
+    }
+
+    if (str_contains($msg, 'Unknown database')) {
+        sendJsonResponse(['error' => 'O banco de dados informado não existe.'], 400);
+    }
+
+    if (str_contains($msg, 'getaddrinfo') || str_contains($msg, 'connect to MySQL server')) {
+        sendJsonResponse(['error' => 'Não foi possível conectar ao servidor MySQL. Verifique o IP/host e se o servidor está ativo.'], 400);
+    }
+
+    sendJsonResponse(['error' => 'Erro ao conectar no banco de dados informado: ' . $msg], 400);
+}
+
+$apiToken = bin2hex(random_bytes(32));
+$clientIp = $_SERVER['REMOTE_ADDR'] ?? null;
+$clientUserAgent = $_SERVER['HTTP_USER_AGENT'] ?? null;
+
+try {
+    $checkStmt = $adminPdo->prepare('
+        SELECT id
+        FROM clientes_import_jobs
+        WHERE db_host = :host
+            AND db_name = :dbname
+            AND db_user = :user
+            AND m3u_url = :m3u_url
+            AND status = :status
+            AND job_type = :job_type
+        ORDER BY id DESC
+        LIMIT 1
+    ');
+    $checkStmt->execute([
+        ':host' => $host,
+        ':dbname' => $dbname,
+        ':user' => $user,
+        ':m3u_url' => $m3uUrl,
+        ':status' => 'running',
+        ':job_type' => 'series',
+    ]);
+    $runningJob = $checkStmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($runningJob) {
+        sendJsonResponse([
+            'error' => sprintf(
+                'Já existe um processamento em andamento (#%d) para esta lista e base de dados. Aguarde a conclusão antes de enviar novamente.',
+                (int) $runningJob['id']
+            ),
+        ], 409);
+    }
+
+    $stmt = $adminPdo->prepare('
+        INSERT INTO clientes_import_jobs (
+            job_type,
+            db_host,
+            db_name,
+            db_user,
+            db_password,
+            m3u_url,
+            api_token,
+            status,
+            progress,
+            message,
+            client_ip,
+            client_user_agent
+        ) VALUES (
+            :job_type,
+            :host,
+            :dbname,
+            :user,
+            :pass,
+            :m3u_url,
+            :token,
+            :status,
+            :progress,
+            :message,
+            :ip,
+            :ua
+        )
+    ');
+    $stmt->execute([
+        ':job_type' => 'series',
+        ':host' => $host,
+        ':dbname' => $dbname,
+        ':user' => $user,
+        ':pass' => $pass,
+        ':m3u_url' => $m3uUrl,
+        ':token' => $apiToken,
+        ':status' => 'queued',
+        ':progress' => 0,
+        ':message' => 'Job aguardando processamento de séries e episódios.',
+        ':ip' => $clientIp,
+        ':ua' => $clientUserAgent,
+    ]);
+} catch (PDOException $e) {
+    sendJsonResponse(['error' => 'Não foi possível registrar o job. Erro: ' . $e->getMessage()], 500);
+}
+
+$jobId = (int) $adminPdo->lastInsertId();
+
+triggerBackgroundWorker('worker_process_series.php', $jobId);
+
+sendJsonResponse([
+    'job_id' => $jobId,
+    'status' => 'queued',
+    'message' => 'Job criado com sucesso e processamento de séries e episódios iniciado.',
+]);

--- a/server/process_series_status.php
+++ b/server/process_series_status.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+
+$adminDbHost = '127.0.0.1';
+$adminDbName = 'joaopedro_xui';
+$adminDbUser = 'joaopedro_user';
+$adminDbPass = 'd@z[VGxj)~FNCft6';
+
+try {
+    $adminPdo = new PDO(
+        "mysql:host={$adminDbHost};dbname={$adminDbName};charset=utf8mb4",
+        $adminDbUser,
+        $adminDbPass,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Erro ao conectar ao banco administrador: ' . $e->getMessage()]);
+    exit;
+}
+
+$jobIdParam = $_GET['job_id'] ?? $_POST['job_id'] ?? null;
+$jobId = is_numeric($jobIdParam) ? (int) $jobIdParam : null;
+
+if (!$jobId) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Parâmetro job_id é obrigatório.']);
+    exit;
+}
+
+$stmt = $adminPdo->prepare('SELECT * FROM clientes_import_jobs WHERE id = :id LIMIT 1');
+$stmt->execute([':id' => $jobId]);
+$job = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$job || ($job['job_type'] ?? null) !== 'series') {
+    http_response_code(404);
+    echo json_encode(['error' => 'Job de séries não encontrado.']);
+    exit;
+}
+
+$response = [
+    'job_id' => (int) $job['id'],
+    'status' => $job['status'],
+    'progress' => (int) $job['progress'],
+    'message' => $job['message'] ?? '',
+    'totals' => [
+        'added' => $job['total_added'] !== null ? (int) $job['total_added'] : null,
+        'skipped' => $job['total_skipped'] !== null ? (int) $job['total_skipped'] : null,
+        'errors' => $job['total_errors'] !== null ? (int) $job['total_errors'] : null,
+    ],
+    'timestamps' => [
+        'created_at' => $job['created_at'] ?? null,
+        'updated_at' => $job['updated_at'] ?? null,
+        'started_at' => $job['started_at'] ?? null,
+        'finished_at' => $job['finished_at'] ?? null,
+    ],
+];
+
+echo json_encode($response, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/server/sql/migrations/20240206_001_add_series_job_type.sql
+++ b/server/sql/migrations/20240206_001_add_series_job_type.sql
@@ -1,0 +1,3 @@
+-- Adiciona o novo tipo de job 'series' à enumeração existente.
+ALTER TABLE `clientes_import_jobs`
+    MODIFY `job_type` ENUM('movies','channels','series') NOT NULL DEFAULT 'movies';

--- a/server/sql/schema.sql
+++ b/server/sql/schema.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS `clientes_import` (
 
 CREATE TABLE IF NOT EXISTS `clientes_import_jobs` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
-  `job_type` enum('movies','channels') NOT NULL DEFAULT 'movies',
+  `job_type` enum('movies','channels','series') NOT NULL DEFAULT 'movies',
   `db_host` varchar(191) NOT NULL,
   `db_name` varchar(191) NOT NULL,
   `db_user` varchar(191) NOT NULL,

--- a/server/worker_process_series.php
+++ b/server/worker_process_series.php
@@ -1,0 +1,877 @@
+<?php
+
+declare(strict_types=1);
+
+if (!function_exists('importador_load_env')) {
+    function importador_load_env(): void
+    {
+        static $loaded = false;
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
+        $paths = [
+            __DIR__ . '/.env',
+            dirname(__DIR__) . '/.env',
+        ];
+
+        $seen = [];
+        foreach ($paths as $path) {
+            if (!is_string($path) || $path === '' || !is_file($path)) {
+                continue;
+            }
+            if (isset($seen[$path])) {
+                continue;
+            }
+            $seen[$path] = true;
+
+            $lines = @file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if ($lines === false) {
+                continue;
+            }
+
+            foreach ($lines as $line) {
+                $line = trim($line);
+                if ($line === '' || $line[0] === '#') {
+                    continue;
+                }
+                if (strpos($line, '=') === false) {
+                    continue;
+                }
+
+                [$name, $value] = array_map('trim', explode('=', $line, 2));
+                if ($name === '') {
+                    continue;
+                }
+
+                putenv("{$name}={$value}");
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+            }
+        }
+    }
+}
+
+importador_load_env();
+
+set_time_limit(0);
+
+const SUPPORTED_TARGET_CONTAINERS = ['mp4', 'mkv', 'avi', 'mpg', 'flv', '3gp', 'm4v', 'wmv', 'mov', 'ts'];
+const SERIES_BATCH_SIZE = 500;
+
+$timeoutEnv = getenv('IMPORTADOR_M3U_TIMEOUT');
+$streamTimeout = ($timeoutEnv !== false && is_numeric($timeoutEnv) && (int) $timeoutEnv > 0)
+    ? (int) $timeoutEnv
+    : 600;
+
+ini_set('default_socket_timeout', (string) $streamTimeout);
+
+if (PHP_SAPI === 'cli' && function_exists('pcntl_signal') && function_exists('pcntl_alarm')) {
+    pcntl_signal(SIGALRM, static function (): void {
+        throw new RuntimeException('Tempo limite do worker atingido.');
+    });
+    pcntl_alarm(max(60, min(3600, $streamTimeout * 2)));
+}
+
+function logInfo(string $message): void
+{
+    $line = '[' . date('c') . '] ' . $message;
+    if (PHP_SAPI === 'cli' && defined('STDOUT')) {
+        fwrite(STDOUT, $line . PHP_EOL);
+    } else {
+        error_log($line);
+    }
+}
+
+function sanitizeMessage(string $message): string
+{
+    $trimmed = trim($message);
+    if (function_exists('mb_substr')) {
+        return mb_substr($trimmed, 0, 2000, 'UTF-8');
+    }
+    return substr($trimmed, 0, 2000);
+}
+
+function updateJob(PDO $adminPdo, int $jobId, array $fields): void
+{
+    if (empty($fields)) {
+        return;
+    }
+
+    $allowed = [
+        'status',
+        'progress',
+        'message',
+        'm3u_file_path',
+        'total_added',
+        'total_skipped',
+        'total_errors',
+        'started_at',
+        'finished_at',
+    ];
+
+    $setParts = [];
+    $params = [':id' => $jobId];
+    foreach ($fields as $column => $value) {
+        if (!in_array($column, $allowed, true)) {
+            continue;
+        }
+        if ($column === 'message' && is_string($value)) {
+            $value = sanitizeMessage($value);
+        }
+        $placeholder = ':' . $column;
+        $setParts[] = "`{$column}` = {$placeholder}";
+        $params[$placeholder] = $value;
+    }
+
+    if (empty($setParts)) {
+        return;
+    }
+
+    $setParts[] = '`updated_at` = NOW()';
+    $sql = 'UPDATE clientes_import_jobs SET ' . implode(', ', $setParts) . ' WHERE id = :id LIMIT 1';
+
+    $stmt = $adminPdo->prepare($sql);
+    $stmt->execute($params);
+}
+
+function fetchJob(PDO $adminPdo, int $jobId): ?array
+{
+    $stmt = $adminPdo->prepare('SELECT * FROM clientes_import_jobs WHERE id = :id LIMIT 1');
+    $stmt->execute([':id' => $jobId]);
+    $job = $stmt->fetch(PDO::FETCH_ASSOC);
+    return $job ?: null;
+}
+
+function normalizaChave(string $valor): string
+{
+    $valor = trim($valor);
+    return function_exists('mb_strtolower') ? mb_strtolower($valor, 'UTF-8') : strtolower($valor);
+}
+
+function isAdultCategory(string $name): bool
+{
+    return stripos($name, 'adulto') !== false || stripos($name, 'xxx') !== false;
+}
+
+function safePregReplace(string $pattern, string $replacement, string $subject): string
+{
+    $result = preg_replace($pattern, $replacement, $subject);
+    if ($result === null) {
+        return $subject;
+    }
+    return $result;
+}
+
+function getStreamTypeByUrl(string $url): ?array
+{
+    if (stripos($url, '/series/') !== false) {
+        return [
+            'type' => 5,
+            'category_type' => 'series',
+            'direct_source' => 1,
+        ];
+    }
+    return null;
+}
+
+function determineTargetContainer(string $url): string
+{
+    $path = parse_url($url, PHP_URL_PATH);
+    $extension = is_string($path) ? strtolower((string) pathinfo($path, PATHINFO_EXTENSION)) : '';
+    if ($extension && in_array($extension, SUPPORTED_TARGET_CONTAINERS, true)) {
+        return $extension;
+    }
+    return 'mp4';
+}
+
+/**
+ * @return Generator<int, array{url: string, tvg_logo: string, group_title: string, episode: string}>
+ */
+function extractSeriesEntries(string $filePath): Generator
+{
+    $handle = fopen($filePath, 'r');
+    if ($handle === false) {
+        throw new RuntimeException('Não foi possível ler o ficheiro M3U.');
+    }
+
+    $currentInfo = [
+        'tvg_logo' => '',
+        'group_title' => 'Séries',
+        'episode' => '',
+    ];
+
+    try {
+        while (($line = fgets($handle)) !== false) {
+            $line = trim($line);
+            if ($line === '') {
+                continue;
+            }
+
+            if (stripos($line, '#EXTINF:') === 0) {
+                preg_match('/tvg-logo="(.*?)"/i', $line, $logoMatch);
+                $currentInfo['tvg_logo'] = $logoMatch[1] ?? '';
+
+                $groupTitle = 'Séries';
+                if (preg_match('/group-title="(.*?)"/i', $line, $groupMatch)) {
+                    $groupTitle = trim($groupMatch[1]);
+                }
+
+                $episodeFull = '';
+                $pos = strpos($line, '",');
+                if ($pos !== false) {
+                    $episodeFull = trim(substr($line, $pos + 2));
+                }
+                if ($episodeFull === '') {
+                    $parts = explode(',', $line, 2);
+                    $episodeFull = trim($parts[1] ?? '');
+                }
+
+                $currentInfo['group_title'] = $groupTitle ?: 'Séries';
+                $currentInfo['episode'] = $episodeFull;
+                continue;
+            }
+
+            if (!filter_var($line, FILTER_VALIDATE_URL)) {
+                continue;
+            }
+
+            yield [
+                'url' => $line,
+                'tvg_logo' => $currentInfo['tvg_logo'] ?? '',
+                'group_title' => $currentInfo['group_title'] ?? 'Séries',
+                'episode' => $currentInfo['episode'] ?? '',
+            ];
+        }
+    } finally {
+        fclose($handle);
+    }
+}
+
+function parseSerieSeasonEpisode(string $rawName): ?array
+{
+    $name = trim($rawName);
+    if ($name === '') {
+        return null;
+    }
+
+    if (!preg_match('/^(.*)\sS(\d{1,2})\s*E(\d{1,3})\s*$/i', $name, $matches)) {
+        return null;
+    }
+
+    $serieRaw = trim($matches[1]);
+
+    $legendPattern = '/\s*(\(|\[)\s*(leg|l)\s*(\]|\))\s*/i';
+    $serieNormalized = safePregReplace($legendPattern, ' [L] ', $serieRaw);
+    $serieNormalized = safePregReplace('/\s+/', ' ', $serieNormalized);
+    $serieNormalized = trim($serieNormalized);
+
+    $hasLegend = stripos($serieNormalized, '[L]') !== false;
+    if ($hasLegend) {
+        $serieNormalized = safePregReplace('/\s*\[L\]\s*/i', ' ', $serieNormalized);
+        $serieNormalized = safePregReplace('/\s+/', ' ', $serieNormalized);
+        $serieNormalized = trim($serieNormalized);
+    }
+
+    $year = null;
+    if (preg_match('/^(.*?)(?:\s*[-\x{2013}\x{2014}]?\s*[\(\[]\s*(\d{4})\s*[\)\]])\s*$/u', $serieNormalized, $yearMatches)) {
+        $serieNormalized = trim($yearMatches[1]);
+        $serieNormalized = safePregReplace('/[\s\x{2013}\x{2014}\-:]+$/u', '', $serieNormalized);
+        $serieNormalized = trim($serieNormalized);
+
+        $possibleYear = (int) $yearMatches[2];
+        if ($possibleYear > 0) {
+            $year = $possibleYear;
+        }
+    }
+
+    $serieNormalized = safePregReplace('/\s+/', ' ', $serieNormalized);
+    $serieNormalized = trim($serieNormalized);
+
+    return [
+        'serie' => $serieNormalized,
+        'season' => (int) $matches[2],
+        'episode' => (int) $matches[3],
+        'full' => $name,
+        'legendado' => $hasLegend,
+        'year' => $year,
+    ];
+}
+
+function createCheckpointMarker(int $processedEntries, string $url): ?string
+{
+    $normalizedUrl = trim($url);
+    if ($processedEntries <= 0 || $normalizedUrl === '') {
+        return null;
+    }
+
+    $hash = hash('sha256', $normalizedUrl);
+    return $processedEntries . ':' . substr($hash, 0, 12);
+}
+
+function buildProgressUpdate(
+    int $processedEntries,
+    int $totalEntries,
+    int $totalAdded,
+    int $totalSkipped,
+    int $totalErrors,
+    ?string $checkpointMarker
+): array {
+    if ($totalEntries > 0) {
+        $progress = 10 + (int) floor(($processedEntries / $totalEntries) * 85);
+        if ($progress > 99) {
+            $progress = 99;
+        }
+    } else {
+        $progress = 99;
+    }
+
+    $message = "Processando séries e episódios ({$processedEntries}/{$totalEntries})...";
+    if ($checkpointMarker !== null) {
+        $message .= ' Último marcador: ' . $checkpointMarker;
+    }
+
+    return [
+        'progress' => $progress,
+        'message' => $message,
+        'total_added' => $totalAdded,
+        'total_skipped' => $totalSkipped,
+        'total_errors' => $totalErrors,
+    ];
+}
+
+function getCategoryId(PDO $pdo, string $name, array &$cache): int
+{
+    $name = trim($name) !== '' ? trim($name) : 'Séries';
+    $key = normalizaChave('series|' . $name);
+
+    if (isset($cache[$key])) {
+        return $cache[$key];
+    }
+
+    $stmt = $pdo->prepare('SELECT id FROM streams_categories WHERE category_type = :type AND category_name = :name LIMIT 1');
+    $stmt->execute([
+        ':type' => 'series',
+        ':name' => $name,
+    ]);
+    $existing = $stmt->fetch(PDO::FETCH_ASSOC);
+    if ($existing) {
+        $cache[$key] = (int) $existing['id'];
+        return $cache[$key];
+    }
+
+    $isAdult = isAdultCategory($name);
+
+    $insert = $pdo->prepare('
+        INSERT INTO streams_categories (category_type, category_name, parent_id, cat_order, is_adult)
+        VALUES (:type, :name, 0, :cat_order, :is_adult)
+    ');
+    $insert->execute([
+        ':type' => 'series',
+        ':name' => $name,
+        ':cat_order' => $isAdult ? 9999 : 99,
+        ':is_adult' => $isAdult ? 1 : 0,
+    ]);
+
+    $id = (int) $pdo->lastInsertId();
+    $cache[$key] = $id;
+    return $id;
+}
+
+function getSeriesId(
+    PDO $pdo,
+    string $title,
+    ?int $year,
+    int $categoryId,
+    ?string $cover,
+    array &$cache,
+    PDOStatement $insertStmt
+): int {
+    $title = trim($title);
+    $yearKey = ($year !== null && $year > 0) ? (string) $year : '';
+    $key = normalizaChave($title . '|' . $yearKey);
+
+    if (isset($cache[$key])) {
+        return $cache[$key];
+    }
+
+    $insertStmt->execute([
+        ':title' => $title,
+        ':category_id' => '[' . $categoryId . ']',
+        ':cover' => $cover ?: null,
+        ':cover_big' => $cover ?: null,
+        ':year' => ($year !== null && $year > 0) ? $year : null,
+    ]);
+
+    $id = (int) $pdo->lastInsertId();
+    $cache[$key] = $id;
+    return $id;
+}
+
+function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
+{
+    $jobId = (int) $job['id'];
+    $host = $job['db_host'];
+    $dbname = $job['db_name'];
+    $user = $job['db_user'];
+    $pass = $job['db_password'];
+    $m3uUrl = $job['m3u_url'];
+
+    $uploadDir = __DIR__ . '/m3u_uploads/';
+    if (!is_dir($uploadDir) && !mkdir($uploadDir, 0777, true) && !is_dir($uploadDir)) {
+        throw new RuntimeException('Não foi possível criar o diretório de uploads.');
+    }
+
+    updateJob($adminPdo, $jobId, [
+        'status' => 'running',
+        'progress' => 1,
+        'message' => 'Iniciando leitura da lista M3U...',
+        'started_at' => date('Y-m-d H:i:s'),
+    ]);
+
+    $opts = stream_context_create([
+        'socket' => ['bindto' => '0.0.0.0:0'],
+        'http' => ['timeout' => $streamTimeout, 'follow_location' => 1, 'user_agent' => 'Importador-XUI/1.0'],
+        'https' => ['timeout' => $streamTimeout, 'follow_location' => 1, 'user_agent' => 'Importador-XUI/1.0'],
+    ]);
+
+    $contents = @file_get_contents($m3uUrl, false, $opts);
+    if ($contents === false) {
+        throw new RuntimeException('Erro ao baixar a lista M3U informada.');
+    }
+
+    $filename = 'series_' . time() . '_' . substr(md5($m3uUrl), 0, 8) . '.m3u';
+    $fullPath = $uploadDir . $filename;
+    if (file_put_contents($fullPath, $contents) === false) {
+        throw new RuntimeException('Erro ao gravar a lista M3U no servidor.');
+    }
+
+    updateJob($adminPdo, $jobId, [
+        'm3u_file_path' => $fullPath,
+        'progress' => 5,
+        'message' => 'Lista M3U salva. Conectando ao banco de destino...'
+    ]);
+
+    try {
+        $pdo = new PDO(
+            "mysql:host={$host};dbname={$dbname};charset=utf8mb4",
+            $user,
+            $pass,
+            [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]
+        );
+    } catch (PDOException $e) {
+        throw new RuntimeException('Erro ao conectar no banco de dados de destino: ' . $e->getMessage());
+    }
+
+    $totalEntries = 0;
+    foreach (extractSeriesEntries($fullPath) as $entry) {
+        if ($entry['episode'] === '') {
+            continue;
+        }
+        $streamInfo = getStreamTypeByUrl($entry['url']);
+        if ($streamInfo === null) {
+            continue;
+        }
+        $totalEntries++;
+    }
+
+    if ($totalEntries === 0) {
+        updateJob($adminPdo, $jobId, ['progress' => 95, 'message' => 'Nenhum episódio válido encontrado. Finalizando...']);
+    } else {
+        updateJob($adminPdo, $jobId, ['progress' => 10, 'message' => "Iniciando importação de {$totalEntries} episódios..."]);
+    }
+
+    $categoryCache = [];
+    $seriesCache = [];
+    $streamCache = [];
+    $episodeCache = [];
+
+    $categoryStmt = $pdo->query('SELECT id, category_name FROM streams_categories WHERE category_type = "series"');
+    while ($row = $categoryStmt->fetch(PDO::FETCH_ASSOC)) {
+        $name = $row['category_name'] ?? '';
+        $key = normalizaChave('series|' . $name);
+        $categoryCache[$key] = (int) $row['id'];
+    }
+
+    $seriesStmt = $pdo->query('SELECT id, title, year FROM streams_series');
+    while ($row = $seriesStmt->fetch(PDO::FETCH_ASSOC)) {
+        $title = $row['title'] ?? '';
+        $yearValue = isset($row['year']) ? (int) $row['year'] : null;
+        if ($yearValue <= 0) {
+            $yearValue = null;
+        }
+        $yearKey = $yearValue !== null ? (string) $yearValue : '';
+        $key = normalizaChave($title . '|' . $yearKey);
+        $seriesCache[$key] = (int) $row['id'];
+    }
+
+    $streamStmt = $pdo->query('SELECT stream_source FROM streams WHERE type = 5');
+    while ($row = $streamStmt->fetch(PDO::FETCH_ASSOC)) {
+        $source = $row['stream_source'] ?? '';
+        if ($source !== '') {
+            $streamCache[$source] = true;
+        }
+    }
+
+    $episodeStmt = $pdo->query('SELECT series_id, season_num, episode_num FROM streams_episodes');
+    while ($row = $episodeStmt->fetch(PDO::FETCH_ASSOC)) {
+        $seriesId = (int) ($row['series_id'] ?? 0);
+        $seasonNum = (int) ($row['season_num'] ?? 0);
+        $episodeNum = (int) ($row['episode_num'] ?? 0);
+        if ($seriesId > 0 && $seasonNum >= 0 && $episodeNum >= 0) {
+            $episodeCache[$seriesId . ':' . $seasonNum . ':' . $episodeNum] = true;
+        }
+    }
+
+    $insertSeriesStmt = $pdo->prepare('
+        INSERT INTO streams_series (
+            title, category_id, cover, cover_big, genre, plot, cast, rating, director,
+            release_date, last_modified, tmdb_id, seasons, episode_run_time, backdrop_path,
+            youtube_trailer, tmdb_language, year, plex_uuid, similar
+        ) VALUES (
+            :title, :category_id, :cover, :cover_big, NULL, NULL, NULL, NULL, NULL,
+            NULL, NOW(), NULL, NULL, NULL, NULL,
+            NULL, NULL, :year, NULL, NULL
+        )
+    ');
+
+    $insertStreamStmt = $pdo->prepare('
+        INSERT INTO streams (
+            type, category_id, stream_display_name, stream_source, stream_icon,
+            notes, enable_transcode, transcode_attributes, custom_ffmpeg,
+            movie_properties, movie_subtitles, read_native, target_container,
+            stream_all, remove_subtitles, `order`, gen_timestamps, direct_source,
+            tv_archive_duration, tv_archive_server_id, tv_archive_pid,
+            vframes_server_id, vframes_pid, movie_symlink, rtmp_output, allow_record,
+            probesize_ondemand, llod, rating, fps_restart, fps_threshold, direct_proxy,
+            added
+        ) VALUES (
+            5, :category_id, :name, :source, :icon,
+            NULL, 0, NULL, NULL,
+            NULL, NULL, 0, :target_container,
+            0, 0, 0, 0, :direct_source,
+            0, 0, 0,
+            0, 0, 0, 0, 0,
+            256000, 0, 0, 0, 90, 0,
+            :added
+        )
+    ');
+
+    $insertEpisodeStmt = $pdo->prepare('
+        INSERT INTO streams_episodes (season_num, episode_num, series_id, stream_id)
+        VALUES (:season, :episode, :series_id, :stream_id)
+    ');
+
+    $processedEntries = 0;
+    $totalAdded = 0;
+    $totalSkipped = 0;
+    $totalErrors = 0;
+    $lastCheckpointMarker = null;
+
+    $inTransaction = false;
+    $batchCount = 0;
+
+    foreach (extractSeriesEntries($fullPath) as $entry) {
+        if ($entry['episode'] === '') {
+            continue;
+        }
+
+        $streamInfo = getStreamTypeByUrl($entry['url']);
+        if ($streamInfo === null) {
+            continue;
+        }
+
+        $processedEntries++;
+        $url = trim($entry['url']);
+        $episodeNameFull = trim($entry['episode']);
+
+        try {
+            if (!$inTransaction) {
+                $pdo->beginTransaction();
+                $inTransaction = true;
+                $batchCount = 0;
+            }
+
+            $categoryId = getCategoryId($pdo, $entry['group_title'] ?? 'Séries', $categoryCache);
+
+            $parsed = parseSerieSeasonEpisode($episodeNameFull);
+            if ($parsed === null) {
+                $totalSkipped++;
+                continue;
+            }
+
+            $serieTitle = $parsed['serie'];
+            if ($parsed['legendado']) {
+                $serieTitle = trim($serieTitle . ' [L]');
+            }
+
+            $seriesId = getSeriesId(
+                $pdo,
+                $serieTitle,
+                $parsed['year'] ?? null,
+                $categoryId,
+                $entry['tvg_logo'] ?? null,
+                $seriesCache,
+                $insertSeriesStmt
+            );
+
+            $streamSource = json_encode([$url], JSON_UNESCAPED_SLASHES);
+            if (isset($streamCache[$streamSource])) {
+                $totalSkipped++;
+                $episodeCache[$seriesId . ':' . $parsed['season'] . ':' . $parsed['episode']] = true;
+                continue;
+            }
+
+            $episodeKey = $seriesId . ':' . $parsed['season'] . ':' . $parsed['episode'];
+            if (isset($episodeCache[$episodeKey])) {
+                $totalSkipped++;
+                continue;
+            }
+
+            $episodeDisplay = preg_replace_callback(
+                '/^(.*?)(\sS\d{1,2}\s*E\d{1,3})\s*$/i',
+                static function (array $matches) use ($serieTitle): string {
+                    return $serieTitle . $matches[2];
+                },
+                $parsed['full']
+            );
+            if ($episodeDisplay === null) {
+                $episodeDisplay = $parsed['full'];
+            }
+            $episodeDisplay = trim($episodeDisplay);
+
+            $targetContainer = determineTargetContainer($url);
+
+            $insertStreamStmt->execute([
+                ':category_id' => '[' . $categoryId . ']',
+                ':name' => $episodeDisplay,
+                ':source' => $streamSource,
+                ':icon' => $entry['tvg_logo'] ?? '',
+                ':target_container' => $targetContainer,
+                ':direct_source' => $streamInfo['direct_source'],
+                ':added' => time(),
+            ]);
+
+            $streamId = (int) $pdo->lastInsertId();
+            $streamCache[$streamSource] = true;
+
+            $insertEpisodeStmt->execute([
+                ':season' => $parsed['season'],
+                ':episode' => $parsed['episode'],
+                ':series_id' => $seriesId,
+                ':stream_id' => $streamId,
+            ]);
+
+            $episodeCache[$episodeKey] = true;
+
+            $totalAdded++;
+            $batchCount++;
+        } catch (Throwable $e) {
+            $totalErrors++;
+            logInfo('Erro ao processar episódio: ' . $e->getMessage());
+            if ($inTransaction) {
+                $pdo->rollBack();
+                $inTransaction = false;
+            }
+            continue;
+        } finally {
+            if ($batchCount >= SERIES_BATCH_SIZE && $inTransaction) {
+                $pdo->commit();
+                $inTransaction = false;
+                $batchCount = 0;
+            }
+
+            $checkpoint = createCheckpointMarker($processedEntries, $url);
+            if ($checkpoint !== null) {
+                $lastCheckpointMarker = $checkpoint;
+            }
+
+            if ($processedEntries % 25 === 0 || $processedEntries === $totalEntries) {
+                $progressUpdate = buildProgressUpdate(
+                    $processedEntries,
+                    $totalEntries,
+                    $totalAdded,
+                    $totalSkipped,
+                    $totalErrors,
+                    $lastCheckpointMarker
+                );
+                updateJob($adminPdo, $jobId, $progressUpdate);
+            }
+        }
+    }
+
+    if ($inTransaction && $pdo->inTransaction()) {
+        $pdo->commit();
+    }
+
+    $summaryLines = [];
+    if ($totalEntries === 0) {
+        $summaryLines[] = 'ℹ️ Nenhum episódio válido foi encontrado para processamento.';
+    } else {
+        if ($processedEntries >= $totalEntries) {
+            $summaryLines[] = "✅ Importação concluída. {$processedEntries} de {$totalEntries} episódios processados.";
+        } else {
+            $summaryLines[] = "⚠️ Importação concluída parcialmente. {$processedEntries} de {$totalEntries} episódios processados.";
+            if ($lastCheckpointMarker !== null) {
+                $summaryLines[] = 'Último checkpoint: ' . $lastCheckpointMarker . '.';
+            }
+        }
+    }
+
+    $summaryLines[] = "➕ Episódios adicionados confirmados: {$totalAdded}";
+    $summaryLines[] = "⏭️ Episódios ignorados: {$totalSkipped}";
+    if ($totalErrors > 0) {
+        $summaryLines[] = "❗ Ocorrências registradas durante a importação: {$totalErrors}.";
+    } else {
+        $summaryLines[] = '✅ Nenhum erro registrado durante a importação.';
+    }
+
+    $summary = implode("\n", $summaryLines) . "\n";
+
+    return [
+        'message' => $summary,
+        'totals' => [
+            'added' => $totalAdded,
+            'skipped' => $totalSkipped,
+            'errors' => $totalErrors,
+        ],
+        'm3u_file_path' => $fullPath,
+    ];
+}
+
+$adminDbHost = '127.0.0.1';
+$adminDbName = 'joaopedro_xui';
+$adminDbUser = 'joaopedro_user';
+$adminDbPass = 'd@z[VGxj)~FNCft6';
+
+try {
+    $adminPdo = new PDO(
+        "mysql:host={$adminDbHost};dbname={$adminDbName};charset=utf8mb4",
+        $adminDbUser,
+        $adminDbPass,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+    );
+} catch (PDOException $e) {
+    logInfo('Erro ao conectar no banco administrador: ' . $e->getMessage());
+    exit(1);
+}
+
+$jobId = null;
+if (PHP_SAPI === 'cli') {
+    global $argv;
+    $jobId = isset($argv[1]) ? (int) $argv[1] : null;
+} else {
+    $jobId = isset($_REQUEST['job_id']) ? (int) $_REQUEST['job_id'] : null;
+}
+
+if (!$jobId) {
+    logInfo('job_id não informado.');
+    if (PHP_SAPI !== 'cli') {
+        header('Content-Type: application/json; charset=utf-8');
+        http_response_code(400);
+        echo json_encode(['error' => 'job_id é obrigatório.']);
+    }
+    exit(1);
+}
+
+$job = fetchJob($adminPdo, $jobId);
+if ($job === null || ($job['job_type'] ?? null) !== 'series') {
+    logInfo('Job de séries não encontrado: ' . $jobId);
+    if (PHP_SAPI !== 'cli') {
+        header('Content-Type: application/json; charset=utf-8');
+        http_response_code(404);
+        echo json_encode(['error' => 'Job de séries não encontrado.']);
+    }
+    exit(1);
+}
+
+if ($job['status'] === 'running') {
+    logInfo('Job já está em execução: ' . $jobId);
+    exit(0);
+}
+
+logInfo('Iniciando processamento do job ' . $jobId);
+
+try {
+    $result = processJob($adminPdo, $job, $streamTimeout);
+
+    $totals = $result['totals'];
+    updateJob($adminPdo, $jobId, [
+        'status' => 'done',
+        'progress' => 100,
+        'message' => sanitizeMessage($result['message']),
+        'total_added' => $totals['added'],
+        'total_skipped' => $totals['skipped'],
+        'total_errors' => $totals['errors'],
+        'finished_at' => date('Y-m-d H:i:s'),
+    ]);
+
+    $stmt = $adminPdo->prepare('
+        INSERT INTO clientes_import (
+            db_host, db_name, db_user, db_password, m3u_url, m3u_file_path, api_token,
+            last_import_status, last_import_message, last_import_at, import_count,
+            client_ip, client_user_agent
+        ) VALUES (
+            :host, :dbname, :user, :pass, :m3u_url, :m3u_file, :token,
+            :status, :msg, NOW(), :total, :ip, :ua
+        )
+    ');
+    $stmt->execute([
+        ':host' => $job['db_host'],
+        ':dbname' => $job['db_name'],
+        ':user' => $job['db_user'],
+        ':pass' => $job['db_password'],
+        ':m3u_url' => $job['m3u_url'],
+        ':m3u_file' => $result['m3u_file_path'],
+        ':token' => $job['api_token'],
+        ':status' => 'sucesso',
+        ':msg' => $result['message'],
+        ':total' => $totals['added'],
+        ':ip' => $job['client_ip'] ?? null,
+        ':ua' => $job['client_user_agent'] ?? null,
+    ]);
+
+    logInfo('Job concluído com sucesso.');
+} catch (Throwable $e) {
+    $errorMessage = sanitizeMessage('❌ Erro ao processar séries: ' . $e->getMessage());
+    updateJob($adminPdo, $jobId, [
+        'status' => 'failed',
+        'message' => $errorMessage,
+        'progress' => 100,
+        'finished_at' => date('Y-m-d H:i:s'),
+    ]);
+
+    try {
+        $stmt = $adminPdo->prepare('
+            INSERT INTO clientes_import (
+                db_host, db_name, db_user, db_password, m3u_url, m3u_file_path, api_token,
+                last_import_status, last_import_message, client_ip, client_user_agent
+            ) VALUES (
+                :host, :dbname, :user, :pass, :m3u_url, :m3u_file, :token,
+                :status, :msg, :ip, :ua
+            )
+        ');
+        $stmt->execute([
+            ':host' => $job['db_host'],
+            ':dbname' => $job['db_name'],
+            ':user' => $job['db_user'],
+            ':pass' => $job['db_password'],
+            ':m3u_url' => $job['m3u_url'],
+            ':m3u_file' => $job['m3u_file_path'] ?? null,
+            ':token' => $job['api_token'],
+            ':status' => 'erro',
+            ':msg' => $errorMessage,
+            ':ip' => $job['client_ip'] ?? null,
+            ':ua' => $job['client_user_agent'] ?? null,
+        ]);
+    } catch (PDOException $logException) {
+        logInfo('Falha ao registrar erro no histórico: ' . $logException->getMessage());
+    }
+
+    logInfo('Erro ao executar job: ' . $e->getMessage());
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add a client form dedicated to series import and wire it to the new series endpoints in the proxy
- expose new series/series_status targets in the client API proxy and add matching server handlers plus a worker to process series and episodes
- update the admin schema with the new `series` job type and include a migration for live databases

## Testing
- php -l cliente/form_import_series.php
- php -l server/process_series.php
- php -l server/process_series_status.php
- php -l server/worker_process_series.php

------
https://chatgpt.com/codex/tasks/task_e_68e07ff65c58832b8c0c2e7ad43a423e