### PR TITLE
Padroniza rótulos do menu na tela de importação de séries

### DIFF
--- a/cliente/form_import_series.php
+++ b/cliente/form_import_series.php
@@ -31,9 +31,21 @@ $actionUrl = $buildLocalUrl('api_proxy.php', ['endpoint' => 'series']);
 $statusUrl = $buildLocalUrl('api_proxy.php', ['endpoint' => 'series_status']);
 
 $navItems = [
-    'canais' => ['label' => 'Canais', 'path' => '', 'icon' => 'fa-tv'],
-    'filmes' => ['label' => 'Filmes', 'path' => 'filmes', 'icon' => 'fa-film'],
-    'series' => ['label' => 'Series', 'path' => 'series', 'icon' => 'fa-layer-group'],
+    'canais' => [
+        'label' => 'Importar Canais',
+        'path' => 'form_import_canais.php',
+        'icon' => 'fa-tv',
+    ],
+    'filmes' => [
+        'label' => 'Importar Filmes',
+        'path' => 'form_import_filmes.php',
+        'icon' => 'fa-film',
+    ],
+    'series' => [
+        'label' => 'Importar Séries',
+        'path' => 'form_import_series.php',
+        'icon' => 'fa-layer-group',
+    ],
 ];
 $currentNavKey = 'series';
 $currentPageLabel = $navItems[$currentNavKey]['label'] ?? 'Menu';


### PR DESCRIPTION
## Summary
- padroniza os rótulos do menu na tela de importação de séries para incluir o prefixo "Importar"
- ajusta os links do menu para apontarem diretamente para os formulários correspondentes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0aec066a4832b8d8ea2d8d7a6cbc0