### PR TITLE
Centraliza navegação das telas de importação

### DIFF
--- a/cliente/form_import_canais.php
+++ b/cliente/form_import_canais.php
@@ -34,32 +34,7 @@ $username = $_POST['username'] ?? '';
 $password = $_POST['password'] ?? '';
 $m3u_url = $_POST['m3u_url'] ?? '';
 
-$currentScript = basename($_SERVER['SCRIPT_NAME'] ?? $_SERVER['PHP_SELF'] ?? '');
-$menuItems = [
-    [
-        'label' => 'Importar Canais',
-        'script' => 'form_import_canais.php',
-        'icon' => 'fa-tv',
-    ],
-    [
-        'label' => 'Importar Filmes',
-        'script' => 'form_import_filmes.php',
-        'icon' => 'fa-film',
-    ],
-    [
-        'label' => 'Importar Séries',
-        'script' => 'form_import_series.php',
-        'icon' => 'fa-layer-group',
-    ],
-];
-
-$currentPageLabel = 'Menu';
-foreach ($menuItems as $item) {
-    if ($currentScript === $item['script']) {
-        $currentPageLabel = $item['label'];
-        break;
-    }
-}
+$currentNavKey = 'canais';
 ?>
 <!DOCTYPE html>
 <html lang="pt-PT">
@@ -791,26 +766,7 @@ foreach ($menuItems as $item) {
 </head>
 <body>
     <div class="container">
-        <header class="nav-container">
-            <div class="nav-bar">
-                <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="navDrawer">
-                    <span class="sr-only">Alternar navegação</span>
-                    <span class="icon icon-hamburger"><i class="fas fa-bars"></i></span>
-                    <span class="icon icon-close"><i class="fas fa-times"></i></span>
-                </button>
-                <span class="nav-title"><?= htmlspecialchars($currentPageLabel, ENT_QUOTES, 'UTF-8'); ?></span>
-            </div>
-            <div class="nav-overlay"></div>
-            <nav class="navigation nav-drawer" id="navDrawer">
-                <?php foreach ($menuItems as $item): ?>
-                    <?php $isActive = $currentScript === $item['script']; ?>
-                    <a class="nav-link<?= $isActive ? ' active' : '' ?>" href="<?= htmlspecialchars($buildLocalUrl($item['script'])); ?>">
-                        <i class="fas <?= htmlspecialchars($item['icon']); ?>"></i>
-                        <span><?= htmlspecialchars($item['label']); ?></span>
-                    </a>
-                <?php endforeach; ?>
-            </nav>
-        </header>
+        <?php include __DIR__ . '/includes/navigation_menu.php'; ?>
 
         <header class="header">
             <h1><i class="fas fa-cloud-upload-alt"></i> Importador M3U</h1>

--- a/cliente/form_import_filmes.php
+++ b/cliente/form_import_filmes.php
@@ -30,32 +30,7 @@ $buildLocalUrl = static function (string $script, array $params = []): string {
 $actionUrl = $buildLocalUrl('api_proxy.php', ['endpoint' => 'filmes']);
 $statusUrl = $buildLocalUrl('api_proxy.php', ['endpoint' => 'filmes_status']);
 
-$currentScript = basename($_SERVER['SCRIPT_NAME'] ?? $_SERVER['PHP_SELF'] ?? '');
-$menuItems = [
-    [
-        'label' => 'Importar Canais',
-        'script' => 'form_import_canais.php',
-        'icon' => 'fa-tv',
-    ],
-    [
-        'label' => 'Importar Filmes',
-        'script' => 'form_import_filmes.php',
-        'icon' => 'fa-film',
-    ],
-    [
-        'label' => 'Importar Séries',
-        'script' => 'form_import_series.php',
-        'icon' => 'fa-layer-group',
-    ],
-];
-
-$currentPageLabel = 'Menu';
-foreach ($menuItems as $item) {
-    if ($currentScript === $item['script']) {
-        $currentPageLabel = $item['label'];
-        break;
-    }
-}
+$currentNavKey = 'filmes';
 
 
 // manter valores preenchidos após submit
@@ -788,28 +763,7 @@ $m3u_url = $_POST['m3u_url'] ?? '';
 </head>
 <body>
     <div class="container">
-        <header class="nav-container">
-            <div class="nav-bar">
-                <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="navDrawer">
-                    <span class="sr-only">Alternar navegação</span>
-                    <span class="icon icon-hamburger"><i class="fas fa-bars"></i></span>
-                    <span class="icon icon-close"><i class="fas fa-times"></i></span>
-                </button>
-                <span class="nav-title"><?= htmlspecialchars($currentPageLabel, ENT_QUOTES, 'UTF-8'); ?></span>
-            </div>
-            <div class="nav-overlay"></div>
-            <nav class="navigation nav-drawer" id="navDrawer">
-                <?php foreach ($menuItems as $item):
-                    $url = $buildLocalUrl($item['script']);
-                    $isActive = $currentScript === $item['script'];
-                ?>
-                    <a class="nav-link<?= $isActive ? ' active' : '' ?>" href="<?= htmlspecialchars($url, ENT_QUOTES, 'UTF-8') ?>">
-                        <i class="fas <?= htmlspecialchars($item['icon'], ENT_QUOTES, 'UTF-8') ?>"></i>
-                        <?= htmlspecialchars($item['label'], ENT_QUOTES, 'UTF-8') ?>
-                    </a>
-                <?php endforeach; ?>
-            </nav>
-        </header>
+        <?php include __DIR__ . '/includes/navigation_menu.php'; ?>
 
         <header class="header">
             <h1><i class="fas fa-cloud-upload-alt"></i> Importador M3U</h1>

--- a/cliente/form_import_series.php
+++ b/cliente/form_import_series.php
@@ -30,13 +30,7 @@ $buildLocalUrl = static function (string $script, array $params = []): string {
 $actionUrl = $buildLocalUrl('api_proxy.php', ['endpoint' => 'series']);
 $statusUrl = $buildLocalUrl('api_proxy.php', ['endpoint' => 'series_status']);
 
-$navItems = [
-    'canais' => ['label' => 'Canais', 'path' => '', 'icon' => 'fa-tv'],
-    'filmes' => ['label' => 'Filmes', 'path' => 'filmes', 'icon' => 'fa-film'],
-    'series' => ['label' => 'Series', 'path' => 'series', 'icon' => 'fa-layer-group'],
-];
 $currentNavKey = 'series';
-$currentPageLabel = $navItems[$currentNavKey]['label'] ?? 'Menu';
 
 
 // manter valores preenchidos após submit
@@ -769,28 +763,7 @@ $m3u_url = $_POST['m3u_url'] ?? '';
 </head>
 <body>
     <div class="container">
-        <header class="nav-container">
-            <div class="nav-bar">
-                <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="navDrawer">
-                    <span class="sr-only">Alternar navegação</span>
-                    <span class="icon icon-hamburger"><i class="fas fa-bars"></i></span>
-                    <span class="icon icon-close"><i class="fas fa-times"></i></span>
-                </button>
-                <span class="nav-title"><?= htmlspecialchars($currentPageLabel, ENT_QUOTES, 'UTF-8'); ?></span>
-            </div>
-            <div class="nav-overlay"></div>
-            <nav class="navigation nav-drawer" id="navDrawer">
-                <?php foreach ($navItems as $key => $navItem):
-                    $url = $buildLocalUrl($navItem['path']);
-                    $isActive = $key === $currentNavKey;
-                ?>
-                    <a class="nav-link<?= $isActive ? ' active' : '' ?>" href="<?= htmlspecialchars($url === '' ? '/' : $url, ENT_QUOTES, 'UTF-8') ?>">
-                        <i class="fas <?= htmlspecialchars($navItem['icon'], ENT_QUOTES, 'UTF-8') ?>"></i>
-                        <?= htmlspecialchars($navItem['label'], ENT_QUOTES, 'UTF-8') ?>
-                    </a>
-                <?php endforeach; ?>
-            </nav>
-        </header>
+        <?php include __DIR__ . '/includes/navigation_menu.php'; ?>
 
         <header class="header">
             <h1><i class="fas fa-cloud-upload-alt"></i> Importador M3U</h1>

--- a/cliente/includes/navigation_menu.php
+++ b/cliente/includes/navigation_menu.php
@@ -1,0 +1,58 @@
+<?php
+$navItems = [
+    'canais' => [
+        'label' => 'Importar Canais',
+        'path' => 'form_import_canais.php',
+        'icon' => 'fa-tv',
+    ],
+    'filmes' => [
+        'label' => 'Importar Filmes',
+        'path' => 'form_import_filmes.php',
+        'icon' => 'fa-film',
+    ],
+    'series' => [
+        'label' => 'Importar Séries',
+        'path' => 'form_import_series.php',
+        'icon' => 'fa-layer-group',
+    ],
+];
+
+if (!isset($currentNavKey) || !array_key_exists($currentNavKey, $navItems)) {
+    $currentScript = basename($_SERVER['SCRIPT_NAME'] ?? $_SERVER['PHP_SELF'] ?? '');
+
+    foreach ($navItems as $key => $navItem) {
+        if ($navItem['path'] === $currentScript) {
+            $currentNavKey = $key;
+            break;
+        }
+    }
+
+    if (!isset($currentNavKey) || !array_key_exists($currentNavKey, $navItems)) {
+        $currentNavKey = array_key_first($navItems);
+    }
+}
+
+$currentPageLabel = $navItems[$currentNavKey]['label'] ?? 'Menu';
+?>
+<header class="nav-container">
+    <div class="nav-bar">
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="navDrawer">
+            <span class="sr-only">Alternar navegação</span>
+            <span class="icon icon-hamburger"><i class="fas fa-bars"></i></span>
+            <span class="icon icon-close"><i class="fas fa-times"></i></span>
+        </button>
+        <span class="nav-title"><?= htmlspecialchars($currentPageLabel, ENT_QUOTES, 'UTF-8'); ?></span>
+    </div>
+    <div class="nav-overlay"></div>
+    <nav class="navigation nav-drawer" id="navDrawer">
+        <?php foreach ($navItems as $key => $navItem):
+            $url = $buildLocalUrl($navItem['path']);
+            $isActive = $key === $currentNavKey;
+        ?>
+            <a class="nav-link<?= $isActive ? ' active' : '' ?>" href="<?= htmlspecialchars($url === '' ? '/' : $url, ENT_QUOTES, 'UTF-8'); ?>">
+                <i class="fas <?= htmlspecialchars($navItem['icon'], ENT_QUOTES, 'UTF-8'); ?>"></i>
+                <?= htmlspecialchars($navItem['label'], ENT_QUOTES, 'UTF-8'); ?>
+            </a>
+        <?php endforeach; ?>
+    </nav>
+</header>


### PR DESCRIPTION
## Summary
- cria um include compartilhado para o menu de navegação das telas de importação
- atualiza os formulários de canais, filmes e séries para usar o menu compartilhado e manter o item ativo correto

## Testing
- php -l cliente/form_import_canais.php
- php -l cliente/form_import_filmes.php
- php -l cliente/form_import_series.php
- php -l cliente/includes/navigation_menu.php

------
https://chatgpt.com/codex/tasks/task_e_68e0aec066a4832b8d8ea2d8d7a6cbc0