### PR TITLE
Use hash-based deduplication for series worker

### DIFF
--- a/server/worker_process_series.php
+++ b/server/worker_process_series.php
@@ -496,7 +496,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
 
     $categoryCache = [];
     $seriesCache = [];
-    $streamCache = [];
+    $streamHashCache = [];
     $episodeCache = [];
 
     $categoryStmt = $pdo->query('SELECT id, category_name FROM streams_categories WHERE category_type = "series"');
@@ -516,14 +516,6 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
         $yearKey = $yearValue !== null ? (string) $yearValue : '';
         $key = normalizaChave($title . '|' . $yearKey);
         $seriesCache[$key] = (int) $row['id'];
-    }
-
-    $streamStmt = $pdo->query('SELECT stream_source FROM streams WHERE type = 5');
-    while ($row = $streamStmt->fetch(PDO::FETCH_ASSOC)) {
-        $source = $row['stream_source'] ?? '';
-        if ($source !== '') {
-            $streamCache[$source] = true;
-        }
     }
 
     $episodeStmt = $pdo->query('SELECT series_id, season_num, episode_num FROM streams_episodes');
@@ -574,6 +566,26 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
         INSERT INTO streams_episodes (season_num, episode_num, series_id, stream_id)
         VALUES (:season, :episode, :series_id, :stream_id)
     ');
+
+    $hashLookupStmt = $adminPdo->prepare('
+        SELECT stream_id
+        FROM clientes_import_stream_hashes
+        WHERE db_host = :host AND db_name = :name AND stream_source_hash = :hash
+        LIMIT 1
+    ');
+    $hashDeleteStmt = $adminPdo->prepare('
+        DELETE FROM clientes_import_stream_hashes
+        WHERE db_host = :host AND db_name = :name AND stream_source_hash = :hash
+        LIMIT 1
+    ');
+    $hashRegisterStmt = $adminPdo->prepare('
+        INSERT INTO clientes_import_stream_hashes (db_host, db_name, stream_id, stream_source_hash)
+        VALUES (:host, :name, :stream_id, :hash)
+        ON DUPLICATE KEY UPDATE
+            stream_id = VALUES(stream_id),
+            updated_at = CURRENT_TIMESTAMP
+    ');
+    $streamExistsStmt = $pdo->prepare('SELECT 1 FROM streams WHERE id = :id LIMIT 1');
 
     $processedEntries = 0;
     $totalAdded = 0;
@@ -628,16 +640,68 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
                 $insertSeriesStmt
             );
 
-            $streamSource = json_encode([$url], JSON_UNESCAPED_SLASHES);
-            if (isset($streamCache[$streamSource])) {
-                $totalSkipped++;
-                $episodeCache[$seriesId . ':' . $parsed['season'] . ':' . $parsed['episode']] = true;
-                continue;
-            }
-
             $episodeKey = $seriesId . ':' . $parsed['season'] . ':' . $parsed['episode'];
             if (isset($episodeCache[$episodeKey])) {
                 $totalSkipped++;
+                continue;
+            }
+
+            $streamSource = json_encode([$url], JSON_UNESCAPED_SLASHES);
+            $streamSourceHash = hash('sha256', $streamSource);
+
+            if (isset($streamHashCache[$streamSourceHash])) {
+                $totalSkipped++;
+                $episodeCache[$episodeKey] = true;
+                continue;
+            }
+
+            $hashParams = [
+                ':host' => $host,
+                ':name' => $dbname,
+                ':hash' => $streamSourceHash,
+            ];
+
+            $existingHash = null;
+            try {
+                $hashLookupStmt->execute($hashParams);
+                $existingHash = $hashLookupStmt->fetch(PDO::FETCH_ASSOC) ?: null;
+            } catch (PDOException $e) {
+                throw new RuntimeException('Erro ao verificar hash de stream: ' . $e->getMessage());
+            } finally {
+                $hashLookupStmt->closeCursor();
+            }
+
+            $shouldSkip = false;
+            if ($existingHash !== null) {
+                $existingStreamId = isset($existingHash['stream_id']) ? (int) $existingHash['stream_id'] : null;
+                $streamStillExists = false;
+
+                if ($existingStreamId !== null && $existingStreamId > 0) {
+                    try {
+                        $streamExistsStmt->execute([':id' => $existingStreamId]);
+                        $streamStillExists = (bool) $streamExistsStmt->fetchColumn();
+                    } catch (PDOException $existsException) {
+                        throw new RuntimeException('Erro ao validar stream existente: ' . $existsException->getMessage());
+                    } finally {
+                        $streamExistsStmt->closeCursor();
+                    }
+                }
+
+                if ($streamStillExists) {
+                    $shouldSkip = true;
+                    $streamHashCache[$streamSourceHash] = true;
+                } else {
+                    try {
+                        $hashDeleteStmt->execute($hashParams);
+                    } catch (PDOException $deleteException) {
+                        throw new RuntimeException('Erro ao limpar hash órfão: ' . $deleteException->getMessage());
+                    }
+                }
+            }
+
+            if ($shouldSkip) {
+                $totalSkipped++;
+                $episodeCache[$episodeKey] = true;
                 continue;
             }
 
@@ -666,7 +730,17 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
             ]);
 
             $streamId = (int) $pdo->lastInsertId();
-            $streamCache[$streamSource] = true;
+            try {
+                $hashRegisterStmt->execute([
+                    ':host' => $host,
+                    ':name' => $dbname,
+                    ':stream_id' => $streamId,
+                    ':hash' => $streamSourceHash,
+                ]);
+            } catch (PDOException $hashException) {
+                throw new RuntimeException('Erro ao registrar hash do stream: ' . $hashException->getMessage());
+            }
+            $streamHashCache[$streamSourceHash] = true;
 
             $insertEpisodeStmt->execute([
                 ':season' => $parsed['season'],


### PR DESCRIPTION
## Summary
- prepare admin hash lookup, delete, and register statements in the series worker
- replace the full stream source preload with per-run hash caching and validation against clientes_import_stream_hashes
- register new stream hashes after insertion and clean orphaned hashes before reinserting episodes

## Testing
- php -l server/worker_process_series.php

------
https://chatgpt.com/codex/tasks/task_e_68e1312b9de4832b83b8bf48fb4be443