### PR TITLE
Add content type metadata to stream hash deduplication

### DIFF
--- a/server/sql/schema.sql
+++ b/server/sql/schema.sql
@@ -59,12 +59,14 @@ CREATE TABLE IF NOT EXISTS `clientes_import_stream_hashes` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `db_host` varchar(191) NOT NULL,
   `db_name` varchar(191) NOT NULL,
+  `content_type` enum('movie','series') NOT NULL,
   `stream_id` int(11) DEFAULT NULL,
   `stream_source_hash` char(64) NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
   `updated_at` timestamp NULL DEFAULT NULL ON UPDATE current_timestamp(),
   PRIMARY KEY (`id`),
-  UNIQUE KEY `uniq_client_stream_hash` (`db_host`,`db_name`,`stream_source_hash`),
+  UNIQUE KEY `uniq_client_stream_hash` (`db_host`,`db_name`,`content_type`,`stream_source_hash`),
+  KEY `idx_content_type` (`content_type`),
   KEY `idx_stream_id` (`stream_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 

--- a/server/worker_process_filmes.php
+++ b/server/worker_process_filmes.php
@@ -494,20 +494,22 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     $totalErrors = $confirmedErrors;
     $lastPersistedCheckpoint = null;
 
+    $hashContentType = 'movie';
+
     $hashLookupStmt = $adminPdo->prepare('
         SELECT stream_id
         FROM clientes_import_stream_hashes
-        WHERE db_host = :host AND db_name = :name AND stream_source_hash = :hash
+        WHERE db_host = :host AND db_name = :name AND content_type = :type AND stream_source_hash = :hash
         LIMIT 1
     ');
     $hashDeleteStmt = $adminPdo->prepare('
         DELETE FROM clientes_import_stream_hashes
-        WHERE db_host = :host AND db_name = :name AND stream_source_hash = :hash
+        WHERE db_host = :host AND db_name = :name AND content_type = :type AND stream_source_hash = :hash
         LIMIT 1
     ');
     $hashRegisterStmt = $adminPdo->prepare('
-        INSERT INTO clientes_import_stream_hashes (db_host, db_name, stream_id, stream_source_hash)
-        VALUES (:host, :name, :stream_id, :hash)
+        INSERT INTO clientes_import_stream_hashes (db_host, db_name, content_type, stream_id, stream_source_hash)
+        VALUES (:host, :name, :type, :stream_id, :hash)
         ON DUPLICATE KEY UPDATE
             stream_id = VALUES(stream_id),
             updated_at = CURRENT_TIMESTAMP
@@ -556,6 +558,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
             $hashParams = [
                 ':host' => $host,
                 ':name' => $dbname,
+                ':type' => $hashContentType,
                 ':hash' => $streamSourceHash,
             ];
 
@@ -671,6 +674,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
                     $hashRegisterStmt->execute([
                         ':host' => $host,
                         ':name' => $dbname,
+                        ':type' => $hashContentType,
                         ':stream_id' => $streamId,
                         ':hash' => $streamSourceHash,
                     ]);

--- a/server/worker_process_series.php
+++ b/server/worker_process_series.php
@@ -496,7 +496,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
 
     $categoryCache = [];
     $seriesCache = [];
-    $streamCache = [];
+    $streamHashCache = [];
     $episodeCache = [];
 
     $categoryStmt = $pdo->query('SELECT id, category_name FROM streams_categories WHERE category_type = "series"');
@@ -516,14 +516,6 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
         $yearKey = $yearValue !== null ? (string) $yearValue : '';
         $key = normalizaChave($title . '|' . $yearKey);
         $seriesCache[$key] = (int) $row['id'];
-    }
-
-    $streamStmt = $pdo->query('SELECT stream_source FROM streams WHERE type = 5');
-    while ($row = $streamStmt->fetch(PDO::FETCH_ASSOC)) {
-        $source = $row['stream_source'] ?? '';
-        if ($source !== '') {
-            $streamCache[$source] = true;
-        }
     }
 
     $episodeStmt = $pdo->query('SELECT series_id, season_num, episode_num FROM streams_episodes');
@@ -574,6 +566,28 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
         INSERT INTO streams_episodes (season_num, episode_num, series_id, stream_id)
         VALUES (:season, :episode, :series_id, :stream_id)
     ');
+
+    $hashContentType = 'series';
+
+    $hashLookupStmt = $adminPdo->prepare('
+        SELECT stream_id
+        FROM clientes_import_stream_hashes
+        WHERE db_host = :host AND db_name = :name AND content_type = :type AND stream_source_hash = :hash
+        LIMIT 1
+    ');
+    $hashDeleteStmt = $adminPdo->prepare('
+        DELETE FROM clientes_import_stream_hashes
+        WHERE db_host = :host AND db_name = :name AND content_type = :type AND stream_source_hash = :hash
+        LIMIT 1
+    ');
+    $hashRegisterStmt = $adminPdo->prepare('
+        INSERT INTO clientes_import_stream_hashes (db_host, db_name, content_type, stream_id, stream_source_hash)
+        VALUES (:host, :name, :type, :stream_id, :hash)
+        ON DUPLICATE KEY UPDATE
+            stream_id = VALUES(stream_id),
+            updated_at = CURRENT_TIMESTAMP
+    ');
+    $streamExistsStmt = $pdo->prepare('SELECT 1 FROM streams WHERE id = :id LIMIT 1');
 
     $processedEntries = 0;
     $totalAdded = 0;
@@ -628,16 +642,69 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
                 $insertSeriesStmt
             );
 
-            $streamSource = json_encode([$url], JSON_UNESCAPED_SLASHES);
-            if (isset($streamCache[$streamSource])) {
-                $totalSkipped++;
-                $episodeCache[$seriesId . ':' . $parsed['season'] . ':' . $parsed['episode']] = true;
-                continue;
-            }
-
             $episodeKey = $seriesId . ':' . $parsed['season'] . ':' . $parsed['episode'];
             if (isset($episodeCache[$episodeKey])) {
                 $totalSkipped++;
+                continue;
+            }
+
+            $streamSource = json_encode([$url], JSON_UNESCAPED_SLASHES);
+            $streamSourceHash = hash('sha256', $streamSource);
+
+            if (isset($streamHashCache[$streamSourceHash])) {
+                $totalSkipped++;
+                $episodeCache[$episodeKey] = true;
+                continue;
+            }
+
+            $hashParams = [
+                ':host' => $host,
+                ':name' => $dbname,
+                ':type' => $hashContentType,
+                ':hash' => $streamSourceHash,
+            ];
+
+            $existingHash = null;
+            try {
+                $hashLookupStmt->execute($hashParams);
+                $existingHash = $hashLookupStmt->fetch(PDO::FETCH_ASSOC) ?: null;
+            } catch (PDOException $e) {
+                throw new RuntimeException('Erro ao verificar hash de stream: ' . $e->getMessage());
+            } finally {
+                $hashLookupStmt->closeCursor();
+            }
+
+            $shouldSkip = false;
+            if ($existingHash !== null) {
+                $existingStreamId = isset($existingHash['stream_id']) ? (int) $existingHash['stream_id'] : null;
+                $streamStillExists = false;
+
+                if ($existingStreamId !== null && $existingStreamId > 0) {
+                    try {
+                        $streamExistsStmt->execute([':id' => $existingStreamId]);
+                        $streamStillExists = (bool) $streamExistsStmt->fetchColumn();
+                    } catch (PDOException $existsException) {
+                        throw new RuntimeException('Erro ao validar stream existente: ' . $existsException->getMessage());
+                    } finally {
+                        $streamExistsStmt->closeCursor();
+                    }
+                }
+
+                if ($streamStillExists) {
+                    $shouldSkip = true;
+                    $streamHashCache[$streamSourceHash] = true;
+                } else {
+                    try {
+                        $hashDeleteStmt->execute($hashParams);
+                    } catch (PDOException $deleteException) {
+                        throw new RuntimeException('Erro ao limpar hash órfão: ' . $deleteException->getMessage());
+                    }
+                }
+            }
+
+            if ($shouldSkip) {
+                $totalSkipped++;
+                $episodeCache[$episodeKey] = true;
                 continue;
             }
 
@@ -666,7 +733,18 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
             ]);
 
             $streamId = (int) $pdo->lastInsertId();
-            $streamCache[$streamSource] = true;
+            try {
+                $hashRegisterStmt->execute([
+                    ':host' => $host,
+                    ':name' => $dbname,
+                    ':type' => $hashContentType,
+                    ':stream_id' => $streamId,
+                    ':hash' => $streamSourceHash,
+                ]);
+            } catch (PDOException $hashException) {
+                throw new RuntimeException('Erro ao registrar hash do stream: ' . $hashException->getMessage());
+            }
+            $streamHashCache[$streamSourceHash] = true;
 
             $insertEpisodeStmt->execute([
                 ':season' => $parsed['season'],


### PR DESCRIPTION
## Summary
- add a content_type column and supporting indexes to clientes_import_stream_hashes
- scope movie and series hash lookups/deletions/registrations by content type in both workers
- tag new hashes with the appropriate content type when registering new streams

## Testing
- php -l server/worker_process_filmes.php
- php -l server/worker_process_series.php

------
https://chatgpt.com/codex/tasks/task_e_68e1312b9de4832b83b8bf48fb4be443