### PR TITLE
Add migration for content_type on stream hash table

### DIFF
--- a/server/sql/migrations/20240415_001_add_stream_hash_content_type.sql
+++ b/server/sql/migrations/20240415_001_add_stream_hash_content_type.sql
@@ -1,0 +1,21 @@
+-- Adiciona a coluna content_type e ajusta os índices conforme o schema atual.
+ALTER TABLE `clientes_import_stream_hashes`
+    ADD COLUMN `content_type` ENUM('movie','series') NOT NULL DEFAULT 'movie' AFTER `db_name`;
+
+-- Garante que registros existentes tenham um valor válido definido.
+UPDATE `clientes_import_stream_hashes`
+SET `content_type` = 'movie'
+WHERE `content_type` IS NULL;
+
+-- Atualiza o índice único para incluir content_type.
+ALTER TABLE `clientes_import_stream_hashes`
+    DROP INDEX `uniq_client_stream_hash`,
+    ADD UNIQUE KEY `uniq_client_stream_hash` (`db_host`, `db_name`, `content_type`, `stream_source_hash`);
+
+-- Adiciona o índice auxiliar utilizado no schema.
+ALTER TABLE `clientes_import_stream_hashes`
+    ADD KEY `idx_content_type` (`content_type`);
+
+-- Remove o default temporário mantendo a coluna como NOT NULL.
+ALTER TABLE `clientes_import_stream_hashes`
+    ALTER COLUMN `content_type` DROP DEFAULT;


### PR DESCRIPTION
## Summary
- add migration to introduce the clientes_import_stream_hashes.content_type column
- backfill existing rows and align unique and supporting indexes with schema.sql
- drop the temporary default after creating the column

## Testing
- not run (migration only)


------
https://chatgpt.com/codex/tasks/task_e_68e1397c8574832b85f27f270b219015