### PR TITLE
Drop clientes_import_stream_hashes table

### DIFF
--- a/server/sql/migrations/20241004_002_drop_clientes_import_stream_hashes.sql
+++ b/server/sql/migrations/20241004_002_drop_clientes_import_stream_hashes.sql
@@ -1,0 +1,2 @@
+-- Remove tabela de hashes persistentes descontinuada
+DROP TABLE IF EXISTS `clientes_import_stream_hashes`;


### PR DESCRIPTION
## Summary
- drop the deprecated clientes_import_stream_hashes table via migration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e14c665c40832bb6ffc8110d410875