### PR TITLE
Improve progress feedback during M3U processing

### DIFF
--- a/server/worker_process_filmes.php
+++ b/server/worker_process_filmes.php
@@ -563,7 +563,7 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     updateJob($adminPdo, $jobId, [
         'm3u_file_path' => $fullPath,
         'progress' => 5,
-        'message' => 'Lista M3U verfificada. Conectando ao banco de destino...'
+        'message' => 'Lista M3U verificada. Conectando ao banco de destino...'
     ]);
 
     try {
@@ -579,6 +579,11 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     } catch (PDOException $e) {
         throw new RuntimeException('Erro ao conectar no banco de dados de destino: ' . $e->getMessage());
     }
+
+    updateJob($adminPdo, $jobId, [
+        'progress' => 7,
+        'message' => 'Banco de destino conectado. Analisando a lista M3U antes da importação...'
+    ]);
 
     $totalEntries = 0;
     foreach (extractEntries($fullPath) as $entry) {

--- a/server/worker_process_series.php
+++ b/server/worker_process_series.php
@@ -652,6 +652,11 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
         throw new RuntimeException('Erro ao conectar no banco de dados de destino: ' . $e->getMessage());
     }
 
+    updateJob($adminPdo, $jobId, [
+        'progress' => 7,
+        'message' => 'Banco de destino conectado. Analisando a lista M3U antes da importação...'
+    ]);
+
     $totalEntries = 0;
     $newSeriesStreamIds = [];
     $newEpisodeStreamIds = [];


### PR DESCRIPTION
## Summary
- adjust filmes and séries workers to update job status once the destination database connection succeeds
- correct the filmes worker message typo and clarify that the list analysis stage is running

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2cc671e9c832bb46fe037a6003ed2