### PR TITLE
Reorder FAQ privacy question across import forms

### DIFF
--- a/cliente/form_import_canais.php
+++ b/cliente/form_import_canais.php
@@ -901,6 +901,17 @@ $m3u_url = $_POST['m3u_url'] ?? '';
 
                 <div class="faq-item">
                     <button class="faq-question" type="button" onclick="toggleFaq(this)">
+                        Minha conexão e meus dados ficam salvos no sistema?
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <p>Não. O Importador Automatizado processa todas as informações em tempo de execução, ou seja, nada é salvo nem armazenado após o uso.</p>
+                        <p>Os dados informados (como IP, usuário, senha ou URL da fonte) não ficam guardados em nossos servidores — tudo é tratado em tempo real, garantindo privacidade e segurança total.</p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
                         O que faz esse sistema?
                         <i class="fas fa-chevron-down"></i>
                     </button>
@@ -922,17 +933,6 @@ $m3u_url = $_POST['m3u_url'] ?? '';
                             <li>Falha de conexão com o servidor</li>
                             <li>URL M3U inválida ou inacessível</li>
                         </ul>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
-                        Minha conexão e meus dados ficam salvos no sistema?
-                        <i class="fas fa-chevron-down"></i>
-                    </button>
-                    <div class="faq-answer">
-                        <p>Não. O Importador Automatizado processa todas as informações em tempo de execução, ou seja, nada é salvo nem armazenado após o uso.</p>
-                        <p>Os dados informados (como IP, usuário, senha ou URL da fonte) não ficam guardados em nossos servidores — tudo é tratado em tempo real, garantindo privacidade e segurança total.</p>
                     </div>
                 </div>
 

--- a/cliente/form_import_filmes.php
+++ b/cliente/form_import_filmes.php
@@ -903,6 +903,17 @@ $m3u_url = $_POST['m3u_url'] ?? '';
 
                 <div class="faq-item">
                     <button class="faq-question" type="button" onclick="toggleFaq(this)">
+                        Minha conexão e meus dados ficam salvos no sistema?
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <p>Não. O Importador Automatizado processa todas as informações em tempo de execução, ou seja, nada é salvo nem armazenado após o uso.</p>
+                        <p>Os dados informados (como IP, usuário, senha ou URL da fonte) não ficam guardados em nossos servidores — tudo é tratado em tempo real, garantindo privacidade e segurança total.</p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
                         O que faz esse sistema?
                         <i class="fas fa-chevron-down"></i>
                     </button>
@@ -924,17 +935,6 @@ $m3u_url = $_POST['m3u_url'] ?? '';
                             <li>Falha de conexão com o servidor</li>
                             <li>URL M3U inválida ou inacessível</li>
                         </ul>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
-                        Minha conexão e meus dados ficam salvos no sistema?
-                        <i class="fas fa-chevron-down"></i>
-                    </button>
-                    <div class="faq-answer">
-                        <p>Não. O Importador Automatizado processa todas as informações em tempo de execução, ou seja, nada é salvo nem armazenado após o uso.</p>
-                        <p>Os dados informados (como IP, usuário, senha ou URL da fonte) não ficam guardados em nossos servidores — tudo é tratado em tempo real, garantindo privacidade e segurança total.</p>
                     </div>
                 </div>
 

--- a/cliente/form_import_series.php
+++ b/cliente/form_import_series.php
@@ -903,6 +903,17 @@ $m3u_url = $_POST['m3u_url'] ?? '';
 
                 <div class="faq-item">
                     <button class="faq-question" type="button" onclick="toggleFaq(this)">
+                        Minha conexão e meus dados ficam salvos no sistema?
+                        <i class="fas fa-chevron-down"></i>
+                    </button>
+                    <div class="faq-answer">
+                        <p>Não. O Importador Automatizado processa todas as informações em tempo de execução, ou seja, nada é salvo nem armazenado após o uso.</p>
+                        <p>Os dados informados (como IP, usuário, senha ou URL da fonte) não ficam guardados em nossos servidores — tudo é tratado em tempo real, garantindo privacidade e segurança total.</p>
+                    </div>
+                </div>
+
+                <div class="faq-item">
+                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
                         O que faz esse sistema?
                         <i class="fas fa-chevron-down"></i>
                     </button>
@@ -924,17 +935,6 @@ $m3u_url = $_POST['m3u_url'] ?? '';
                             <li>Falha de conexão com o servidor</li>
                             <li>URL M3U inválida ou inacessível</li>
                         </ul>
-                    </div>
-                </div>
-
-                <div class="faq-item">
-                    <button class="faq-question" type="button" onclick="toggleFaq(this)">
-                        Minha conexão e meus dados ficam salvos no sistema?
-                        <i class="fas fa-chevron-down"></i>
-                    </button>
-                    <div class="faq-answer">
-                        <p>Não. O Importador Automatizado processa todas as informações em tempo de execução, ou seja, nada é salvo nem armazenado após o uso.</p>
-                        <p>Os dados informados (como IP, usuário, senha ou URL da fonte) não ficam guardados em nossos servidores — tudo é tratado em tempo real, garantindo privacidade e segurança total.</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- move the privacy-related FAQ question to the second position in each import form so the answer appears earlier for users

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e2ee54b4e8832b833a1b0e80b6ff61