### PR TITLE
Atualiza mensagens de processamento em tempo real das listas M3U

### DIFF
--- a/server/worker_process_canais.php
+++ b/server/worker_process_canais.php
@@ -206,19 +206,19 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
 
     $contents = @file_get_contents($m3uUrl, false, $opts);
     if ($contents === false) {
-        throw new RuntimeException('Erro ao baixar a lista M3U informada.');
+        throw new RuntimeException('Não foi possível acessar a lista M3U informada em tempo real.');
     }
 
     $filename = 'canais_' . time() . '_' . substr(md5($m3uUrl), 0, 8) . '.m3u';
     $fullPath = $uploadDir . $filename;
     if (file_put_contents($fullPath, $contents) === false) {
-        throw new RuntimeException('Erro ao gravar a lista M3U no servidor.');
+        throw new RuntimeException('Não foi possível preparar o processamento temporário da lista M3U.');
     }
 
     updateJob($adminPdo, $jobId, [
         'm3u_file_path' => $fullPath,
         'progress' => CHANNEL_PROGRESS_DOWNLOAD,
-        'message' => 'Lista M3U verificada. Conectando ao banco de destino...'
+        'message' => 'Lista M3U verificada para processamento imediato, sem armazenamento permanente. Conectando ao banco de destino...'
     ]);
 
     try {

--- a/server/worker_process_filmes.php
+++ b/server/worker_process_filmes.php
@@ -536,13 +536,13 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     $fullPath = $uploadDir . $filename;
     $readStream = @fopen($m3uUrl, 'rb', false, $opts);
     if ($readStream === false) {
-        throw new RuntimeException('Erro ao baixar a lista M3U informada.');
+        throw new RuntimeException('Não foi possível acessar a lista M3U informada em tempo real.');
     }
 
     $writeStream = @fopen($fullPath, 'wb');
     if ($writeStream === false) {
         fclose($readStream);
-        throw new RuntimeException('Erro ao gravar a lista M3U no servidor.');
+        throw new RuntimeException('Não foi possível preparar o processamento temporário da lista M3U.');
     }
 
     $bytesCopied = @stream_copy_to_stream($readStream, $writeStream);
@@ -551,19 +551,19 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
 
     if ($bytesCopied === false) {
         @unlink($fullPath);
-        throw new RuntimeException('Erro ao gravar a lista M3U no servidor.');
+        throw new RuntimeException('Não foi possível preparar o processamento temporário da lista M3U.');
     }
 
     $fileSize = @filesize($fullPath);
     if ($fileSize === false || $fileSize === 0) {
         @unlink($fullPath);
-        throw new RuntimeException('Erro ao gravar a lista M3U no servidor.');
+        throw new RuntimeException('Não foi possível preparar o processamento temporário da lista M3U.');
     }
 
     updateJob($adminPdo, $jobId, [
         'm3u_file_path' => $fullPath,
         'progress' => 5,
-        'message' => 'Lista M3U verificada. Conectando ao banco de destino...'
+        'message' => 'Lista M3U verificada para processamento imediato, sem armazenamento permanente. Conectando ao banco de destino...'
     ]);
 
     try {

--- a/server/worker_process_series.php
+++ b/server/worker_process_series.php
@@ -608,13 +608,13 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
     $fullPath = $uploadDir . $filename;
     $readStream = @fopen($m3uUrl, 'rb', false, $opts);
     if ($readStream === false) {
-        throw new RuntimeException('Erro ao baixar a lista M3U informada.');
+        throw new RuntimeException('Não foi possível acessar a lista M3U informada em tempo real.');
     }
 
     $writeStream = @fopen($fullPath, 'wb');
     if ($writeStream === false) {
         fclose($readStream);
-        throw new RuntimeException('Erro ao gravar a lista M3U no servidor.');
+        throw new RuntimeException('Não foi possível preparar o processamento temporário da lista M3U.');
     }
 
     $bytesCopied = @stream_copy_to_stream($readStream, $writeStream);
@@ -623,19 +623,19 @@ function processJob(PDO $adminPdo, array $job, int $streamTimeout): array
 
     if ($bytesCopied === false) {
         @unlink($fullPath);
-        throw new RuntimeException('Erro ao gravar a lista M3U no servidor.');
+        throw new RuntimeException('Não foi possível preparar o processamento temporário da lista M3U.');
     }
 
     $fileSize = @filesize($fullPath);
     if ($fileSize === false || $fileSize === 0) {
         @unlink($fullPath);
-        throw new RuntimeException('Erro ao gravar a lista M3U no servidor.');
+        throw new RuntimeException('Não foi possível preparar o processamento temporário da lista M3U.');
     }
 
     updateJob($adminPdo, $jobId, [
         'm3u_file_path' => $fullPath,
         'progress' => 5,
-        'message' => 'Lista M3U salva. Conectando ao banco de destino...'
+        'message' => 'Lista M3U carregada temporariamente, sem armazenamento permanente. Conectando ao banco de destino...'
     ]);
 
     try {


### PR DESCRIPTION
## Summary
- atualiza mensagens de erro para refletir acesso em tempo real às listas M3U
- ajusta mensagens informativas para reforçar que não há armazenamento permanente dos dados

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3bb526974832ba7703fd91019787e